### PR TITLE
Expose recycle bin quota metrics. 

### DIFF
--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -113,24 +113,26 @@ func (o *RecycleCollector) collectRecycleDF() error {
 		panic(err)
 	}
 
-	usedbytes, err := strconv.ParseFloat(mds.UsedBytes, 64)
-	if err == nil {
-		o.UsedBytes.WithLabelValues(mds.RecycleBin).Set(usedbytes)
-	}
+	for _, m := range mds {
+		usedbytes, err := strconv.ParseFloat(m.UsedBytes, 64)
+		if err == nil {
+			o.UsedBytes.WithLabelValues(m.RecycleBin).Set(usedbytes)
+		}
 
-	maxbytes, err := strconv.ParseFloat(mds.MaxBytes, 64)
-	if err == nil {
-		o.MaxBytes.WithLabelValues(mds.RecycleBin).Set(maxbytes)
-	}
+		maxbytes, err := strconv.ParseFloat(m.MaxBytes, 64)
+		if err == nil {
+			o.MaxBytes.WithLabelValues(m.RecycleBin).Set(maxbytes)
+		}
 
-	lifetime, err := strconv.ParseFloat(mds.Lifetime, 64)
-	if err == nil {
-		o.Lifetime.WithLabelValues(mds.RecycleBin).Set(lifetime)
-	}
+		lifetime, err := strconv.ParseFloat(m.Lifetime, 64)
+		if err == nil {
+			o.Lifetime.WithLabelValues(m.RecycleBin).Set(lifetime)
+		}
 
-	ratio, err := strconv.ParseFloat(mds.Ratio, 64)
-	if err == nil {
-		o.Ratio.WithLabelValues(mds.RecycleBin).Set(ratio)
+		ratio, err := strconv.ParseFloat(m.Ratio, 64)
+		if err == nil {
+			o.Ratio.WithLabelValues(m.RecycleBin).Set(ratio)
+		}
 	}
 
 	return nil

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -1,0 +1,157 @@
+package collector
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.cern.ch/rvalverd/eos_exporter/eosclient"
+	//"os"
+	//"bufio"
+	//"strings"
+)
+
+// eos recycle -m
+// recycle-bin=/eos/homecanary/proc/recycle/ usedbytes=365327522885 maxbytes=100000000000000 volumeusage=0.37% inodeusage=1.19% lifetime=15552000 ratio=0.800000
+
+type RecycleCollector struct {
+	UsedBytes          *prometheus.GaugeVec
+	MaxBytes           *prometheus.GaugeVec
+	VolumeUsagePercent *prometheus.GaugeVec
+	InodeUsagePercent  *prometheus.GaugeVec
+	Lifetime           *prometheus.GaugeVec
+	Ratio              *prometheus.GaugeVec
+}
+
+//NewRecycleCollector creates an cluster of the RecycleCollector
+func NewRecycleCollector(cluster string) *RecycleCollector {
+	labels := make(prometheus.Labels)
+	labels["cluster"] = cluster
+	namespace := "eos"
+	return &RecycleCollector{
+
+		UsedBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "recyle_usedbytes",
+				Help:        "Recycle Used Bytes",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+		MaxBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "recycle_maxbytes",
+				Help:        "Recycle Max Bytes",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+		VolumeUsagePercent: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "recycle_volumeusagepercent",
+				Help:        "Volume usage (percent)",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+		InodeUsagePercent: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   "eos",
+				Name:        "recycle_inodeusagepercent",
+				Help:        "Inode usage (percent)",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+		Lifetime: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   "eos",
+				Name:        "recycle_lifetime",
+				Help:        "Recycle lifetime",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+		Ratio: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   "eos",
+				Name:        "recycle_ratio",
+				Help:        "Space Disk Read Rate in MB/s",
+				ConstLabels: labels,
+			},
+			[]string{"recycle-bin"},
+		),
+	}
+}
+
+func (o *RecycleCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		o.UsedBytes,
+		o.MaxBytes,
+		o.VolumeUsagePercent,
+		o.InodeUsagePercent,
+		o.Lifetime,
+		o.Ratio,
+	}
+}
+
+func (o *RecycleCollector) collectRecycleDF() error {
+	ins := getEOSInstance()
+	url := "root://" + ins + ".cern.ch"
+	opt := &eosclient.Options{URL: url}
+	client, err := eosclient.New(opt)
+	if err != nil {
+		panic(err)
+	}
+
+	mds, err := client.Recycle(context.Background(), "root")
+	if err != nil {
+		panic(err)
+	}
+
+	usedbytes, err := strconv.ParseFloat(mds.UsedBytes, 64)
+	if err == nil {
+		o.UsedBytes.WithLabelValues(mds.RecycleBin).Set(usedbytes)
+	}
+
+	maxbytes, err := strconv.ParseFloat(mds.MaxBytes, 64)
+	if err == nil {
+		o.MaxBytes.WithLabelValues(mds.RecycleBin).Set(maxbytes)
+	}
+
+	lifetime, err := strconv.ParseFloat(mds.Lifetime, 64)
+	if err == nil {
+		o.Lifetime.WithLabelValues(mds.RecycleBin).Set(lifetime)
+	}
+
+	ratio, err := strconv.ParseFloat(mds.Ratio, 64)
+	if err == nil {
+		o.Ratio.WithLabelValues(mds.RecycleBin).Set(ratio)
+	}
+
+	return nil
+
+} // collectRecycleDF()
+
+// Describe sends the descriptors of each SpaceCollector related metrics we have defined
+func (o *RecycleCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range o.collectorList() {
+		metric.Describe(ch)
+	}
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+func (o *RecycleCollector) Collect(ch chan<- prometheus.Metric) {
+
+	if err := o.collectRecycleDF(); err != nil {
+		log.Println("failed collecting recycle metrics:", err)
+	}
+
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -32,7 +32,7 @@ func NewRecycleCollector(cluster string) *RecycleCollector {
 		UsedBytes: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
-				Name:        "recyle_used_bytes",
+				Name:        "recycle_used_bytes",
 				Help:        "Recycle Used Bytes",
 				ConstLabels: labels,
 			},

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -49,24 +49,24 @@ func NewRecycleCollector(cluster string) *RecycleCollector {
 			},
 			[]string{"recycle-bin"},
 		),
-		VolumeUsagePercent: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace:   namespace,
-				Name:        "recycle_volumeusagepercent",
-				Help:        "Volume usage (percent)",
-				ConstLabels: labels,
-			},
-			[]string{"recycle-bin"},
-		),
-		InodeUsagePercent: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace:   "eos",
-				Name:        "recycle_inodeusagepercent",
-				Help:        "Inode usage (percent)",
-				ConstLabels: labels,
-			},
-			[]string{"recycle-bin"},
-		),
+		// VolumeUsagePercent: prometheus.NewGaugeVec(
+		// 	prometheus.GaugeOpts{
+		// 		Namespace:   namespace,
+		// 		Name:        "recycle_volumeusagepercent",
+		// 		Help:        "Volume usage (percent)",
+		// 		ConstLabels: labels,
+		// 	},
+		// 	[]string{"recycle-bin"},
+		// ),
+		// InodeUsagePercent: prometheus.NewGaugeVec(
+		// 	prometheus.GaugeOpts{
+		// 		Namespace:   "eos",
+		// 		Name:        "recycle_inodeusagepercent",
+		// 		Help:        "Inode usage (percent)",
+		// 		ConstLabels: labels,
+		// 	},
+		// 	[]string{"recycle-bin"},
+		// ),
 		Lifetime: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   "eos",
@@ -92,8 +92,8 @@ func (o *RecycleCollector) collectorList() []prometheus.Collector {
 	return []prometheus.Collector{
 		o.UsedBytes,
 		o.MaxBytes,
-		o.VolumeUsagePercent,
-		o.InodeUsagePercent,
+		// o.VolumeUsagePercent,
+		// o.InodeUsagePercent,
 		o.Lifetime,
 		o.Ratio,
 	}

--- a/eos_exporter.go
+++ b/eos_exporter.go
@@ -71,6 +71,7 @@ func NewEOSExporter(instance string) *EOSExporter {
 			collector.NewNSCollector(instance),         // eos namespace information
 			collector.NewNSActivityCollector(instance), // eos namespace activity information
 			collector.NewNSBatchCollector(instance),    // eos namespace potential batch overload information
+			collector.NewRecycleCollector(instance),    // eos recycle bin information
 		},
 	}
 }

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -1188,13 +1188,10 @@ func (c *Client) parseAppIOInfo(line string) (*IOInfo, error) {
 
 // Data struct //
 type RecycleInfo struct {
-	UsedBytes          string
-	MaxBytes           string
-	VolumeUsagePercent string
-	InodeUsagePercent  string
-	Lifetime           string
-	Ratio              string
-	RecycleBin         string
+	UsedBytes string
+	MaxBytes  string
+	Lifetime  string
+	Ratio     string
 }
 
 // Launch recycle command //
@@ -1239,11 +1236,8 @@ func (c *Client) parseRecycleInfo(raw string) ([]*RecycleInfo, error) {
 func (c *Client) parseRecycleLineInfo(line string) (*RecycleInfo, error) {
 	kv := getMap(line)
 	rb := &RecycleInfo{
-		kv["recycle-bin"],
 		kv["usedbytes"],
 		kv["maxbytes"],
-		kv["volumeusage"],
-		kv["inodeusage"],
 		kv["lifetime"],
 		kv["ratio"],
 	}


### PR DESCRIPTION
Exposes output of `eos recycle -m`. Inode stats are still missing for now as they are not available in EOS monitoring format.

Metrics added:

```
# HELP eos_recycle_lifetime_seconds Recycle purges files older than this
# TYPE eos_recycle_lifetime_seconds gauge
eos_recycle_lifetime_seconds{cluster="eoshomecanary"} 1.5552e+07

# HELP eos_recycle_max_bytes Recycle Max Bytes
# TYPE eos_recycle_max_bytes gauge
eos_recycle_max_bytes{cluster="eoshomecanary"} 1e+14

# HELP eos_recycle_ratio Recycle purge kicks in above the fill rate
# TYPE eos_recycle_ratio gauge
eos_recycle_ratio{cluster="eoshomecanary"} 0.8

# HELP eos_recycle_used_bytes Recycle Used Bytes
# TYPE eos_recycle_used_bytes gauge
eos_recyle_used_bytes{cluster="eoshomecanary"} 3.65327544905e+11
```