### PR TITLE
Add fsck collector, add missing space metric. Closes #11 #5

### DIFF
--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -1,0 +1,111 @@
+package collector
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.cern.ch/rvalverd/eos_exporter/eosclient"
+)
+
+type FsckCollector struct {
+	Count *prometheus.GaugeVec
+}
+
+//NewFSCollector creates an cluster of the FSCollector and instantiates
+// the individual metrics that show information about the FS.
+func NewFsckCollector(cluster string) *FsckCollector {
+	labels := make(prometheus.Labels)
+	labels["cluster"] = cluster
+	namespace := "eos"
+	return &FsckCollector{
+		Count: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "fsck_report",
+				Help:        "fsck inconsistency report: eos fsck report -a",
+				ConstLabels: labels,
+			},
+			[]string{"fs", "tag"},
+		),
+	}
+}
+
+func (o *FsckCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		o.Count,
+	}
+}
+
+// func getEOSInstance() string {
+// 	// Get the EOS cluster name from MGM's filesystem
+// 	var str string
+
+// 	file, err := os.Open("/etc/sysconfig/eos_env")
+// 	if err != nil {
+// 		fmt.Println(err)
+// 	}
+// 	defer file.Close()
+
+// 	scanner := bufio.NewScanner(file)
+// 	for scanner.Scan() {
+// 		l := scanner.Text()
+// 		if strings.HasPrefix(l, "EOS_MGM_ALIAS=") {
+// 			s := strings.Split(l, "EOS_MGM_ALIAS=")
+// 			str = strings.Replace(s[1], "\"", "", -1)
+// 		}
+// 	}
+
+// 	if err := scanner.Err(); err != nil {
+// 		fmt.Println(err)
+// 	}
+
+// 	return str
+// }
+
+func (o *FsckCollector) collectFsckDF() error {
+	ins := getEOSInstance()
+	url := "root://" + ins
+	opt := &eosclient.Options{URL: url}
+	client, err := eosclient.New(opt)
+	if err != nil {
+		panic(err)
+	}
+
+	mds, err := client.FsckReport(context.Background(), "root")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, m := range mds {
+
+		count, err := strconv.ParseFloat(m.Count, 64)
+		if err == nil {
+			o.Count.WithLabelValues(m.Fs, m.Tag).Set(count)
+		}
+	}
+
+	return nil
+
+} // collectFsckDF()
+
+// Describe sends the descriptors of each FSCollector related metrics we have defined
+func (o *FsckCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range o.collectorList() {
+		metric.Describe(ch)
+	}
+	//ch <- o.ScrubbingStateDesc
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+func (o *FsckCollector) Collect(ch chan<- prometheus.Metric) {
+
+	if err := o.collectFsckDF(); err != nil {
+		log.Println("failed collecting space metrics:", err)
+	}
+
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/collector/space.go
+++ b/collector/space.go
@@ -10,34 +10,35 @@ import (
 )
 
 type SpaceCollector struct {
-	CfgGroupSize                        *prometheus.GaugeVec
-	CfgGroupMod                         *prometheus.GaugeVec
-	Nofs                                *prometheus.GaugeVec
-	AvgStatDiskLoad                     *prometheus.GaugeVec
-	SigStatDiskLoad                     *prometheus.GaugeVec
-	SumStatDiskReadratemb               *prometheus.GaugeVec
-	SumStatDiskWriteratemb              *prometheus.GaugeVec
-	SumStatNetEthratemib                *prometheus.GaugeVec
-	SumStatNetInratemib                 *prometheus.GaugeVec
-	SumStatNetOutratemib                *prometheus.GaugeVec
-	SumStatRopen                        *prometheus.GaugeVec
-	SumStatWopen                        *prometheus.GaugeVec
-	SumStatStatfsUsedbytes              *prometheus.GaugeVec
-	SumStatStatfsFreebytes              *prometheus.GaugeVec
-	SumStatStatfsCapacity               *prometheus.GaugeVec
-	SumStatUsedfiles                    *prometheus.GaugeVec
-	SumStatStatfsFfiles                 *prometheus.GaugeVec
-	SumStatStatfsFiles                  *prometheus.GaugeVec
-	SumStatStatfsCapacityConfigstatusRw *prometheus.GaugeVec
-	SumNofsConfigstatusRw               *prometheus.GaugeVec
-	CfgQuota                            *prometheus.GaugeVec
-	CfgNominalsize                      *prometheus.GaugeVec
-	CfgBalancer                         *prometheus.GaugeVec
-	CfgBalancerThreshold                *prometheus.GaugeVec
-	SumStatBalancerRunning              *prometheus.GaugeVec
-	SumStatDrainerRunning               *prometheus.GaugeVec
-	SumStatDiskIopsConfigstatusRw       *prometheus.GaugeVec
-	SumStatDiskBwConfigstatusRw         *prometheus.GaugeVec
+	CfgGroupSize                         *prometheus.GaugeVec
+	CfgGroupMod                          *prometheus.GaugeVec
+	Nofs                                 *prometheus.GaugeVec
+	AvgStatDiskLoad                      *prometheus.GaugeVec
+	SigStatDiskLoad                      *prometheus.GaugeVec
+	SumStatDiskReadratemb                *prometheus.GaugeVec
+	SumStatDiskWriteratemb               *prometheus.GaugeVec
+	SumStatNetEthratemib                 *prometheus.GaugeVec
+	SumStatNetInratemib                  *prometheus.GaugeVec
+	SumStatNetOutratemib                 *prometheus.GaugeVec
+	SumStatRopen                         *prometheus.GaugeVec
+	SumStatWopen                         *prometheus.GaugeVec
+	SumStatStatfsUsedbytes               *prometheus.GaugeVec
+	SumStatStatfsFreebytes               *prometheus.GaugeVec
+	SumStatStatfsCapacity                *prometheus.GaugeVec
+	SumStatUsedfiles                     *prometheus.GaugeVec
+	SumStatStatfsFfiles                  *prometheus.GaugeVec
+	SumStatStatfsFiles                   *prometheus.GaugeVec
+	SumStatStatfsCapacityConfigstatusRw  *prometheus.GaugeVec
+	SumNofsConfigstatusRw                *prometheus.GaugeVec
+	CfgQuota                             *prometheus.GaugeVec
+	CfgNominalsize                       *prometheus.GaugeVec
+	CfgBalancer                          *prometheus.GaugeVec
+	CfgBalancerThreshold                 *prometheus.GaugeVec
+	SumStatBalancerRunning               *prometheus.GaugeVec
+	SumStatDrainerRunning                *prometheus.GaugeVec
+	SumStatDiskIopsConfigstatusRw        *prometheus.GaugeVec
+	SumStatDiskBwConfigstatusRw          *prometheus.GaugeVec
+	SumStatStatfsFreebytesConfigstatusRw *prometheus.GaugeVec
 }
 
 //NewSpaceCollector creates an cluster of the SpaceCollector
@@ -299,6 +300,17 @@ func NewSpaceCollector(cluster string) *SpaceCollector {
 			},
 			[]string{"space"},
 		),
+		SumStatStatfsFreebytesConfigstatusRw: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "space_statfs_freebytes_configrw",
+				Help:        "Space free bytes counting on filesystem in rw mode",
+				ConstLabels: labels,
+			},
+			[]string{"space"},
+		),
+
+		// SumStatStatfsFreebytesConfigstatusRw
 	}
 }
 
@@ -332,6 +344,7 @@ func (o *SpaceCollector) collectorList() []prometheus.Collector {
 		o.SumStatDrainerRunning,
 		o.SumStatDiskIopsConfigstatusRw,
 		o.SumStatDiskBwConfigstatusRw,
+		o.SumStatStatfsFreebytesConfigstatusRw,
 	}
 }
 
@@ -498,6 +511,11 @@ func (o *SpaceCollector) collectSpaceDF() error {
 		nomsize, err := strconv.ParseFloat(m.CfgNominalsize, 64)
 		if err == nil {
 			o.CfgNominalsize.WithLabelValues(m.Name).Set(nomsize)
+		}
+
+		fbytesRW, err := strconv.ParseFloat(m.SumStatStatfsFreebytesConfigstatusRw, 64)
+		if err == nil {
+			o.SumStatStatfsFreebytesConfigstatusRw.WithLabelValues(m.Name).Set(fbytesRW)
 		}
 
 	}

--- a/eos_exporter.go
+++ b/eos_exporter.go
@@ -73,6 +73,7 @@ func NewEOSExporter(instance string) *EOSExporter {
 			collector.NewNSBatchCollector(instance),    // eos namespace potential batch overload information
 			collector.NewRecycleCollector(instance),    // eos recycle bin information
 			collector.NewWhoCollector(instance),        // eos who information
+			collector.NewFsckCollector(instance),       // eos fsck information
 		},
 	}
 }

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -92,39 +92,6 @@ type NodeInfo struct {
 	SumStatNetOutratemib  string
 }
 
-type SpaceInfo struct {
-	Type                                string
-	Name                                string
-	CfgGroupSize                        string
-	CfgGroupMod                         string
-	Nofs                                string
-	AvgStatDiskLoad                     string
-	SigStatDiskLoad                     string
-	SumStatDiskReadratemb               string
-	SumStatDiskWriteratemb              string
-	SumStatNetEthratemib                string
-	SumStatNetInratemib                 string
-	SumStatNetOutratemib                string
-	SumStatRopen                        string
-	SumStatWopen                        string
-	SumStatStatfsUsedbytes              string
-	SumStatStatfsFreebytes              string
-	SumStatStatfsCapacity               string
-	SumStatUsedfiles                    string
-	SumStatStatfsFfiles                 string
-	SumStatStatfsFiles                  string
-	SumStatStatfsCapacityConfigstatusRw string
-	SumNofsConfigstatusRw               string
-	CfgQuota                            string
-	CfgNominalsize                      string
-	CfgBalancer                         string
-	CfgBalancerThreshold                string
-	SumStatBalancerRunning              string
-	SumStatDrainerRunning               string
-	SumStatDiskIopsConfigstatusRw       string
-	SumStatDiskBwConfigstatusRw         string
-}
-
 type GroupInfo struct {
 	Name                   string
 	CfgStatus              string
@@ -654,63 +621,6 @@ func (c *Client) parseNodeInfo(line string) (*NodeInfo, error) {
 		SumStatNetOutratemib:  kv["sum.stat.net.outratemib"],
 	}
 	return fst, nil
-}
-
-// Gathers the information of all spaces.
-func (c *Client) parseSpacesInfo(raw string) ([]*SpaceInfo, error) {
-	spaceinfos := []*SpaceInfo{}
-	rawLines := strings.Split(raw, "\n")
-	for _, rl := range rawLines {
-		if rl == "" {
-			continue
-		}
-		space, err := c.parseSpaceInfo(rl)
-
-		if err != nil {
-			return nil, err
-		}
-		spaceinfos = append(spaceinfos, space)
-	}
-	return spaceinfos, nil
-}
-
-// Gathers information of one single space
-func (c *Client) parseSpaceInfo(line string) (*SpaceInfo, error) {
-	//kv := make(map[string]string)
-	kv := getMap(line)
-	space := &SpaceInfo{
-		kv["type"],
-		kv["name"],
-		kv["cfg.groupsize"],
-		kv["cfg.groupmod"],
-		kv["nofs"],
-		kv["avg.stat.disk.load"],
-		kv["sig.stat.disk.load"],
-		kv["sum.stat.disk.readratemb"],
-		kv["sum.stat.disk.writeratemb"],
-		kv["sum.stat.net.ethratemib"],
-		kv["sum.stat.net.inratemib"],
-		kv["sum.stat.net.outratemib"],
-		kv["sum.stat.ropen"],
-		kv["sum.stat.wopen"],
-		kv["sum.stat.statfs.usedbytes"],
-		kv["sum.stat.statfs.freebytes"],
-		kv["sum.stat.statfs.capacity"],
-		kv["sum.stat.usedfiles"],
-		kv["sum.stat.statfs.ffiles"],
-		kv["sum.stat.statfs.files"],
-		kv["sum.stat.statfs.capacity?configstatus@rw"],
-		kv["sum.<n>?configstatus@rw"],
-		kv["cfg.quota"],
-		kv["cfg.nominalsize"],
-		kv["cfg.balancer"],
-		kv["cfg.balancer.threshold"],
-		kv["sum.stat.balancer.running"],
-		kv["sum.stat.drainer.running"],
-		kv["sum.stat.disk.iops?configstatus@rw"],
-		kv["sum.stat.disk.bw?configstatus@rw"],
-	}
-	return space, nil
 }
 
 // Gathers information of all groups
@@ -1327,6 +1237,103 @@ func (c *Client) parseWhoInfo(raw string) ([]*WhoInfo, error) {
 		whoInfo = append(whoInfo, who)
 	}
 	return whoInfo, nil
+}
+
+// ----------------------------------------//
+// EOS SPACE    INFORMATION 			    //
+// ----------------------------------------//
+
+// struct definition
+type SpaceInfo struct {
+	Type                                 string
+	Name                                 string
+	CfgGroupSize                         string
+	CfgGroupMod                          string
+	Nofs                                 string
+	AvgStatDiskLoad                      string
+	SigStatDiskLoad                      string
+	SumStatDiskReadratemb                string
+	SumStatDiskWriteratemb               string
+	SumStatNetEthratemib                 string
+	SumStatNetInratemib                  string
+	SumStatNetOutratemib                 string
+	SumStatRopen                         string
+	SumStatWopen                         string
+	SumStatStatfsUsedbytes               string
+	SumStatStatfsFreebytes               string
+	SumStatStatfsCapacity                string
+	SumStatUsedfiles                     string
+	SumStatStatfsFfiles                  string
+	SumStatStatfsFiles                   string
+	SumStatStatfsCapacityConfigstatusRw  string
+	SumNofsConfigstatusRw                string
+	CfgQuota                             string
+	CfgNominalsize                       string
+	CfgBalancer                          string
+	CfgBalancerThreshold                 string
+	SumStatBalancerRunning               string
+	SumStatDrainerRunning                string
+	SumStatDiskIopsConfigstatusRw        string
+	SumStatDiskBwConfigstatusRw          string
+	SumStatStatfsFreebytesConfigstatusRw string
+}
+
+// Gathers the information of all spaces.
+func (c *Client) parseSpacesInfo(raw string) ([]*SpaceInfo, error) {
+	spaceinfos := []*SpaceInfo{}
+	rawLines := strings.Split(raw, "\n")
+	for _, rl := range rawLines {
+		if rl == "" {
+			continue
+		}
+		space, err := c.parseSpaceInfo(rl)
+
+		if err != nil {
+			return nil, err
+		}
+		spaceinfos = append(spaceinfos, space)
+	}
+	return spaceinfos, nil
+}
+
+// Gathers information of one single space
+func (c *Client) parseSpaceInfo(line string) (*SpaceInfo, error) {
+	//kv := make(map[string]string)
+	kv := getMap(line)
+	space := &SpaceInfo{
+		kv["type"],
+		kv["name"],
+		kv["cfg.groupsize"],
+		kv["cfg.groupmod"],
+		kv["nofs"],
+		kv["avg.stat.disk.load"],
+		kv["sig.stat.disk.load"],
+		kv["sum.stat.disk.readratemb"],
+		kv["sum.stat.disk.writeratemb"],
+		kv["sum.stat.net.ethratemib"],
+		kv["sum.stat.net.inratemib"],
+		kv["sum.stat.net.outratemib"],
+		kv["sum.stat.ropen"],
+		kv["sum.stat.wopen"],
+		kv["sum.stat.statfs.usedbytes"],
+		kv["sum.stat.statfs.freebytes"],
+		kv["sum.stat.statfs.capacity"],
+		kv["sum.stat.usedfiles"],
+		kv["sum.stat.statfs.ffiles"],
+		kv["sum.stat.statfs.files"],
+		kv["sum.stat.statfs.capacity?configstatus@rw"],
+		kv["sum.<n>?configstatus@rw"],
+		kv["cfg.quota"],
+		kv["cfg.nominalsize"],
+		kv["cfg.balancer"],
+		kv["cfg.balancer.threshold"],
+		kv["sum.stat.balancer.running"],
+		kv["sum.stat.drainer.running"],
+		kv["sum.stat.disk.iops?configstatus@rw"],
+		kv["sum.stat.disk.bw?configstatus@rw"],
+		kv["sum.stat.statfs.freebytes?configstatus@rw"],
+	}
+	return space, nil
 }
 
 // ----------------------------------------//

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -1384,9 +1384,9 @@ func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 func (c *Client) parseFsckLineInfo(line string) (*FsckInfo, error) {
 	kv := getMap(line)
 	rb := &FsckInfo{
-		kv["fsid"],
-		kv["tag"],
-		kv["count"],
+		Fs:    kv["fsid"],
+		Tag:   strings.Trim(kv["tag"], "\""), // clean double quotes
+		Count: kv["count"],
 	}
 	return rb, nil
 }


### PR DESCRIPTION
- Add new eos fsck collector that exposes fsck report metrics.
- Add a missing freebytes@configstatus=rw in the space collector. 