### PR TITLE
Fsck collector uses now fsck stat instead of fsck report, for performance reasons.

### DIFF
--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -23,11 +23,11 @@ func NewFsckCollector(cluster string) *FsckCollector {
 		Count: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
-				Name:        "fsck_report",
-				Help:        "fsck inconsistency report: eos fsck report -a",
+				Name:        "fsck_stat",
+				Help:        "fsck inconsistency report: eos fsck stat",
 				ConstLabels: labels,
 			},
-			[]string{"fs", "tag"},
+			[]string{"tag"},
 		),
 	}
 }
@@ -82,7 +82,7 @@ func (o *FsckCollector) collectFsckDF() error {
 
 		count, err := strconv.ParseFloat(m.Count, 64)
 		if err == nil {
-			o.Count.WithLabelValues(m.Fs, m.Tag).Set(count)
+			o.Count.WithLabelValues(m.Tag).Set(count)
 		}
 	}
 

--- a/eos_exporter.spec
+++ b/eos_exporter.spec
@@ -58,6 +58,9 @@ rm -rf %buildroot/
 %systemd_preun %{name}.service
 
 %changelog
+* Mon Mar 06 2023 Roberto Valverde <rvalverd@cern.ch> 0.1.1-1
+- Fsck collector uses now eos fsck stat instead of fsck report for performance reasons.
+- Fsck does not report by filesystem anymore, for performance reasons.
 * Fri Mar 03 2023 Roberto Valverde <rvalverd@cern.ch> 0.1.0-1
 - Mgm url gathered from EOS_MGM_ALIAS, removes dependency of CERN domain
 - Added eos fsck collector for exposing fsck metrics 

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	osuser "os/user"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1339,11 +1340,12 @@ func (c *Client) parseSpaceInfo(line string) (*SpaceInfo, error) {
 // ----------------------------------------//
 // EOS FSCK    INFORMATION 			       //
 // ----------------------------------------//
-// Gathers metrics from `eos fsck report -a` command that breaks insconsistencies by filesystem
+// Gathers metrics from `eos fsck stat`
+// Currently not in monitoring format
+// `eos fsck report` is more detailed, but can be expensive.
 
 // Data struct //
 type FsckInfo struct {
-	Fs    string
 	Tag   string
 	Count string
 }
@@ -1363,7 +1365,8 @@ func (c *Client) FsckReport(ctx context.Context, username string) ([]*FsckInfo, 
 	ctxWt, cancel = context.WithTimeout(ctx, cmdTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctxWt, "/usr/bin/eos", "-r", unixUser.Uid, unixUser.Gid, "fsck", "report", "-a")
+	//cmd := exec.CommandContext(ctxWt, "/usr/bin/eos", "-r", unixUser.Uid, unixUser.Gid, "fsck", "report", "-a")
+	cmd := exec.CommandContext(ctxWt, "/usr/bin/eos", "-r", unixUser.Uid, unixUser.Gid, "fsck", "stat")
 	stdout, _, err := c.execute(cmd)
 	if err != nil {
 		return nil, err
@@ -1375,8 +1378,9 @@ func (c *Client) FsckReport(ctx context.Context, username string) ([]*FsckInfo, 
 func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 	fsckInfo := []*FsckInfo{}
 	rawLines := strings.Split(raw, "\n")
+	var re = regexp.MustCompile(`d_cx_diff|d_mem_sz_diff|m_cx_diff|m_mem_sz_diff|orphans_n|rep_diff_n|rep_missing_n|unreg_n`)
 	for _, rl := range rawLines {
-		if rl == "" {
+		if !re.MatchString(rl) {
 			continue
 		}
 		fsck, err := c.parseFsckLineInfo(rl)
@@ -1389,11 +1393,10 @@ func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 }
 
 func (c *Client) parseFsckLineInfo(line string) (*FsckInfo, error) {
-	kv := getMap(line)
+	splitedLine := strings.Split(line, " ")
 	rb := &FsckInfo{
-		Fs:    kv["fsid"],
-		Tag:   strings.Trim(kv["tag"], "\""), // clean double quotes
-		Count: kv["count"],
+		Tag:   splitedLine[3],
+		Count: splitedLine[5],
 	}
 	return rb, nil
 }

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -1380,14 +1380,16 @@ func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 	rawLines := strings.Split(raw, "\n")
 	var re = regexp.MustCompile(`d_cx_diff|d_mem_sz_diff|m_cx_diff|m_mem_sz_diff|orphans_n|rep_diff_n|rep_missing_n|unreg_n`)
 	for _, rl := range rawLines {
-		if !re.MatchString(rl) {
+		if !strings.Contains(rl, "Info") && re.MatchString(rl) {
+			fsck, err := c.parseFsckLineInfo(rl)
+			if err != nil {
+				return nil, err
+			}
+			fsckInfo = append(fsckInfo, fsck)
+		} else {
 			continue
 		}
-		fsck, err := c.parseFsckLineInfo(rl)
-		if err != nil {
-			return nil, err
-		}
-		fsckInfo = append(fsckInfo, fsck)
+
 	}
 	return fsckInfo, nil
 }

--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -1380,7 +1380,7 @@ func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 	rawLines := strings.Split(raw, "\n")
 	var re = regexp.MustCompile(`d_cx_diff|d_mem_sz_diff|m_cx_diff|m_mem_sz_diff|orphans_n|rep_diff_n|rep_missing_n|unreg_n`)
 	for _, rl := range rawLines {
-		if !strings.Contains(rl, "Info") && re.MatchString(rl) {
+		if re.MatchString(rl) {
 			fsck, err := c.parseFsckLineInfo(rl)
 			if err != nil {
 				return nil, err
@@ -1395,10 +1395,10 @@ func (c *Client) parseFsckInfo(raw string) ([]*FsckInfo, error) {
 }
 
 func (c *Client) parseFsckLineInfo(line string) (*FsckInfo, error) {
-	splitedLine := strings.Split(line, " ")
+	fields := strings.Fields(line)
 	rb := &FsckInfo{
-		Tag:   splitedLine[3],
-		Count: splitedLine[5],
+		Tag:   fields[3],
+		Count: fields[5],
 	}
 	return rb, nil
 }


### PR DESCRIPTION
`eos fsck stat` uses cached values to print the number of inconsistencies while `eos fsck report` it does the actual inconsistencies count based on information from leveldb, which can be a long process.  This change also drop the count by filesystem as it's only provided by `eos fsck report`. 