### PR TITLE
Reset gauge metrics - Closes #23

### DIFF
--- a/collector/fs.go
+++ b/collector/fs.go
@@ -396,6 +396,37 @@ func (o *FSCollector) collectFSDF() error {
 		panic(err)
 	}
 
+	// Reset Gauge metrics to remove metrics of non existing filesystems
+
+	o.StatBoot.Reset()
+	o.Configstatus.Reset()
+	o.StatDiskLoad.Reset()
+	o.StatDiskReadratemb.Reset()
+	o.StatDiskWriteratemb.Reset()
+	o.StatNetEthratemib.Reset()
+	o.StatNetInratemib.Reset()
+	o.StatNetOutratemib.Reset()
+	o.StatRopen.Reset()
+	o.StatWopen.Reset()
+	o.StatStatfsFreebytes.Reset()
+	o.StatStatfsUsedbytes.Reset()
+	o.StatStatfsCapacity.Reset()
+	o.StatStatfsFfree.Reset()
+	o.StatStatfsFused.Reset()
+	o.StatStatfsFiles.Reset()
+	o.Drainstatus.Reset()
+	o.StatDrainprogress.Reset()
+	o.StatDrainfiles.Reset()
+	o.StatDrainbytesleft.Reset()
+	o.StatDrainretry.Reset()
+	o.StatDrainFailed.Reset()
+	o.StatActive.Reset()
+	o.StatBalancerRunning.Reset()
+	o.StatDrainerRunning.Reset()
+	o.StatDiskIops.Reset()
+	o.StatDiskBw.Reset()
+	o.StatHealth.Reset()
+
 	for _, m := range mds {
 
 		// Boot Status
@@ -435,90 +466,75 @@ func (o *FSCollector) collectFSDF() error {
 			config_status = 0
 		}
 
-		o.Configstatus.Reset()
 		o.Configstatus.WithLabelValues(m.Id, m.Host).Set(float64(config_status))
 
 		diskload, err := strconv.ParseFloat(m.StatDiskLoad, 64)
 		if err == nil {
-			o.StatDiskLoad.Reset()
 			o.StatDiskLoad.WithLabelValues(m.Id, m.Host).Set(diskload)
 		}
 
 		diskr, err := strconv.ParseFloat(m.StatDiskReadratemb, 64)
 		if err == nil {
-			o.StatDiskReadratemb.Reset()
 			o.StatDiskReadratemb.WithLabelValues(m.Id, m.Host).Set(diskr)
 		}
 
 		diskw, err := strconv.ParseFloat(m.StatDiskWriteratemb, 64)
 		if err == nil {
-			o.StatDiskWriteratemb.Reset()
 			o.StatDiskWriteratemb.WithLabelValues(m.Id, m.Host).Set(diskw)
 		}
 
 		ethrate, err := strconv.ParseFloat(m.StatNetEthratemib, 64)
 		if err == nil {
-			o.StatNetEthratemib.Reset()
 			o.StatNetEthratemib.WithLabelValues(m.Id, m.Host).Set(ethrate)
 		}
 
 		inrate, err := strconv.ParseFloat(m.StatNetInratemib, 64)
 		if err == nil {
-			o.StatNetInratemib.Reset()
 			o.StatNetInratemib.WithLabelValues(m.Id, m.Host).Set(inrate)
 		}
 
 		outrate, err := strconv.ParseFloat(m.StatNetOutratemib, 64)
 		if err == nil {
-			o.StatNetOutratemib.Reset()
 			o.StatNetOutratemib.WithLabelValues(m.Id, m.Host).Set(outrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.StatRopen, 64)
 		if err == nil {
-			o.StatRopen.Reset()
 			o.StatRopen.WithLabelValues(m.Id, m.Host).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.StatWopen, 64)
 		if err == nil {
-			o.StatWopen.Reset()
 			o.StatWopen.WithLabelValues(m.Id, m.Host).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.StatStatfsUsedbytes, 64)
 		if err == nil {
-			o.StatStatfsUsedbytes.Reset()
 			o.StatStatfsUsedbytes.WithLabelValues(m.Id, m.Host).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.StatStatfsFreebytes, 64)
 		if err == nil {
-			o.StatStatfsFreebytes.Reset()
 			o.StatStatfsFreebytes.WithLabelValues(m.Id, m.Host).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.StatStatfsCapacity, 64)
 		if err == nil {
-			o.StatStatfsCapacity.Reset()
 			o.StatStatfsCapacity.WithLabelValues(m.Id, m.Host).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.StatStatfsFused, 64)
 		if err == nil {
-			o.StatStatfsFused.Reset()
 			o.StatStatfsFused.WithLabelValues(m.Id, m.Host).Set(ufiles)
 		}
 
 		ffree, err := strconv.ParseFloat(m.StatStatfsFfree, 64)
 		if err == nil {
-			o.StatStatfsFfree.Reset()
 			o.StatStatfsFfree.WithLabelValues(m.Id, m.Host).Set(ffree)
 		}
 
 		files, err := strconv.ParseFloat(m.StatStatfsFiles, 64)
 		if err == nil {
-			o.StatStatfsFiles.Reset()
 			o.StatStatfsFiles.WithLabelValues(m.Id, m.Host).Set(files)
 		}
 
@@ -540,42 +556,35 @@ func (o *FSCollector) collectFSDF() error {
 			drain_status = 0
 		}
 
-		o.Drainstatus.Reset()
 		o.Drainstatus.WithLabelValues(m.Id, m.Host).Set(float64(drain_status))
 
 		balr, err := strconv.ParseFloat(m.StatBalancerRunning, 64)
 		if err == nil {
-			o.StatBalancerRunning.Reset()
 			o.StatBalancerRunning.WithLabelValues(m.Id, m.Host).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.StatDrainerRunning, 64)
 		if err == nil {
-			o.StatDrainerRunning.Reset()
 			o.StatDrainerRunning.WithLabelValues(m.Id, m.Host).Set(drainr)
 		}
 
 		drainretry, err := strconv.ParseFloat(m.StatDrainretry, 64)
 		if err == nil {
-			o.StatDrainretry.Reset()
 			o.StatDrainretry.WithLabelValues(m.Id, m.Host).Set(drainretry)
 		}
 
 		drainfailed, err := strconv.ParseFloat(m.StatDrainFailed, 64)
 		if err == nil {
-			o.StatDrainFailed.Reset()
 			o.StatDrainFailed.WithLabelValues(m.Id, m.Host).Set(drainfailed)
 		}
 
 		diskiops, err := strconv.ParseFloat(m.StatDiskIops, 64)
 		if err == nil {
-			o.StatDiskIops.Reset()
 			o.StatDiskIops.WithLabelValues(m.Id, m.Host).Set(diskiops)
 		}
 
 		diskbw, err := strconv.ParseFloat(m.StatDiskBw, 64)
 		if err == nil {
-			o.StatDiskBw.Reset()
 			o.StatDiskBw.WithLabelValues(m.Id, m.Host).Set(diskbw)
 		}
 
@@ -591,7 +600,6 @@ func (o *FSCollector) collectFSDF() error {
 			active_status = 1
 		}
 
-		o.StatActive.Reset()
 		o.StatActive.WithLabelValues(m.Id, m.Host).Set(float64(active_status))
 
 		// Health
@@ -602,7 +610,6 @@ func (o *FSCollector) collectFSDF() error {
 		} else {
 			health = 1
 		}
-		o.StatHealth.Reset()
 		o.StatHealth.WithLabelValues(m.Id, m.Host).Set(float64(health))
 	}
 

--- a/collector/fs.go
+++ b/collector/fs.go
@@ -382,10 +382,6 @@ func getEOSInstance() string {
 	return str
 }
 
-func (o *FSCollector) resetMetrics() error {
-
-}
-
 func (o *FSCollector) collectFSDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins

--- a/collector/fs.go
+++ b/collector/fs.go
@@ -61,7 +61,7 @@ type FSCollector struct {
 	StatHealthIndicator        *prometheus.GaugeVec
 }
 
-//NewFSCollector creates an cluster of the FSCollector and instantiates
+// NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
 func NewFSCollector(cluster string) *FSCollector {
 	labels := make(prometheus.Labels)
@@ -382,6 +382,10 @@ func getEOSInstance() string {
 	return str
 }
 
+func (o *FSCollector) resetMetrics() error {
+
+}
+
 func (o *FSCollector) collectFSDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
@@ -416,6 +420,7 @@ func (o *FSCollector) collectFSDF() error {
 			boot_status = 4
 		}
 
+		o.StatBoot.Reset()
 		o.StatBoot.WithLabelValues(m.Id, m.Host).Set(float64(boot_status))
 
 		// Config Status
@@ -434,75 +439,90 @@ func (o *FSCollector) collectFSDF() error {
 			config_status = 0
 		}
 
+		o.Configstatus.Reset()
 		o.Configstatus.WithLabelValues(m.Id, m.Host).Set(float64(config_status))
 
 		diskload, err := strconv.ParseFloat(m.StatDiskLoad, 64)
 		if err == nil {
+			o.StatDiskLoad.Reset()
 			o.StatDiskLoad.WithLabelValues(m.Id, m.Host).Set(diskload)
 		}
 
 		diskr, err := strconv.ParseFloat(m.StatDiskReadratemb, 64)
 		if err == nil {
+			o.StatDiskReadratemb.Reset()
 			o.StatDiskReadratemb.WithLabelValues(m.Id, m.Host).Set(diskr)
 		}
 
 		diskw, err := strconv.ParseFloat(m.StatDiskWriteratemb, 64)
 		if err == nil {
+			o.StatDiskWriteratemb.Reset()
 			o.StatDiskWriteratemb.WithLabelValues(m.Id, m.Host).Set(diskw)
 		}
 
 		ethrate, err := strconv.ParseFloat(m.StatNetEthratemib, 64)
 		if err == nil {
+			o.StatNetEthratemib.Reset()
 			o.StatNetEthratemib.WithLabelValues(m.Id, m.Host).Set(ethrate)
 		}
 
 		inrate, err := strconv.ParseFloat(m.StatNetInratemib, 64)
 		if err == nil {
+			o.StatNetInratemib.Reset()
 			o.StatNetInratemib.WithLabelValues(m.Id, m.Host).Set(inrate)
 		}
 
 		outrate, err := strconv.ParseFloat(m.StatNetOutratemib, 64)
 		if err == nil {
+			o.StatNetOutratemib.Reset()
 			o.StatNetOutratemib.WithLabelValues(m.Id, m.Host).Set(outrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.StatRopen, 64)
 		if err == nil {
+			o.StatRopen.Reset()
 			o.StatRopen.WithLabelValues(m.Id, m.Host).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.StatWopen, 64)
 		if err == nil {
+			o.StatWopen.Reset()
 			o.StatWopen.WithLabelValues(m.Id, m.Host).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.StatStatfsUsedbytes, 64)
 		if err == nil {
+			o.StatStatfsUsedbytes.Reset()
 			o.StatStatfsUsedbytes.WithLabelValues(m.Id, m.Host).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.StatStatfsFreebytes, 64)
 		if err == nil {
+			o.StatStatfsFreebytes.Reset()
 			o.StatStatfsFreebytes.WithLabelValues(m.Id, m.Host).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.StatStatfsCapacity, 64)
 		if err == nil {
+			o.StatStatfsCapacity.Reset()
 			o.StatStatfsCapacity.WithLabelValues(m.Id, m.Host).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.StatStatfsFused, 64)
 		if err == nil {
+			o.StatStatfsFused.Reset()
 			o.StatStatfsFused.WithLabelValues(m.Id, m.Host).Set(ufiles)
 		}
 
 		ffree, err := strconv.ParseFloat(m.StatStatfsFfree, 64)
 		if err == nil {
+			o.StatStatfsFfree.Reset()
 			o.StatStatfsFfree.WithLabelValues(m.Id, m.Host).Set(ffree)
 		}
 
 		files, err := strconv.ParseFloat(m.StatStatfsFiles, 64)
 		if err == nil {
+			o.StatStatfsFiles.Reset()
 			o.StatStatfsFiles.WithLabelValues(m.Id, m.Host).Set(files)
 		}
 
@@ -524,35 +544,42 @@ func (o *FSCollector) collectFSDF() error {
 			drain_status = 0
 		}
 
+		o.Drainstatus.Reset()
 		o.Drainstatus.WithLabelValues(m.Id, m.Host).Set(float64(drain_status))
 
 		balr, err := strconv.ParseFloat(m.StatBalancerRunning, 64)
 		if err == nil {
+			o.StatBalancerRunning.Reset()
 			o.StatBalancerRunning.WithLabelValues(m.Id, m.Host).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.StatDrainerRunning, 64)
 		if err == nil {
+			o.StatDrainerRunning.Reset()
 			o.StatDrainerRunning.WithLabelValues(m.Id, m.Host).Set(drainr)
 		}
 
 		drainretry, err := strconv.ParseFloat(m.StatDrainretry, 64)
 		if err == nil {
+			o.StatDrainretry.Reset()
 			o.StatDrainretry.WithLabelValues(m.Id, m.Host).Set(drainretry)
 		}
 
 		drainfailed, err := strconv.ParseFloat(m.StatDrainFailed, 64)
 		if err == nil {
+			o.StatDrainFailed.Reset()
 			o.StatDrainFailed.WithLabelValues(m.Id, m.Host).Set(drainfailed)
 		}
 
 		diskiops, err := strconv.ParseFloat(m.StatDiskIops, 64)
 		if err == nil {
+			o.StatDiskIops.Reset()
 			o.StatDiskIops.WithLabelValues(m.Id, m.Host).Set(diskiops)
 		}
 
 		diskbw, err := strconv.ParseFloat(m.StatDiskBw, 64)
 		if err == nil {
+			o.StatDiskBw.Reset()
 			o.StatDiskBw.WithLabelValues(m.Id, m.Host).Set(diskbw)
 		}
 
@@ -568,6 +595,7 @@ func (o *FSCollector) collectFSDF() error {
 			active_status = 1
 		}
 
+		o.StatActive.Reset()
 		o.StatActive.WithLabelValues(m.Id, m.Host).Set(float64(active_status))
 
 		// Health
@@ -578,6 +606,7 @@ func (o *FSCollector) collectFSDF() error {
 		} else {
 			health = 1
 		}
+		o.StatHealth.Reset()
 		o.StatHealth.WithLabelValues(m.Id, m.Host).Set(float64(health))
 	}
 

--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -13,7 +13,7 @@ type FsckCollector struct {
 	Count *prometheus.GaugeVec
 }
 
-//NewFSCollector creates an cluster of the FSCollector and instantiates
+// NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
 func NewFsckCollector(cluster string) *FsckCollector {
 	labels := make(prometheus.Labels)
@@ -77,6 +77,8 @@ func (o *FsckCollector) collectFsckDF() error {
 	if err != nil {
 		panic(err)
 	}
+
+	o.Count.Reset()
 
 	for _, m := range mds {
 

--- a/collector/group.go
+++ b/collector/group.go
@@ -295,6 +295,32 @@ func (o *GroupCollector) collectGroupDF() error {
 		panic(err)
 	}
 
+	// Reset gauge metrics to remove metrics of deleted groups
+
+	o.CfgStatus.Reset()
+	o.Nofs.Reset()
+	o.AvgStatDiskLoad.Reset()
+	o.SigStatDiskLoad.Reset()
+	o.SumStatDiskReadratemb.Reset()
+	o.SumStatDiskWriteratemb.Reset()
+	o.SumStatNetEthratemib.Reset()
+	o.SumStatNetInratemib.Reset()
+	o.SumStatNetOutratemib.Reset()
+	o.SumStatRopen.Reset()
+	o.SumStatWopen.Reset()
+	o.SumStatStatfsUsedbytes.Reset()
+	o.SumStatStatfsFreebytes.Reset()
+	o.SumStatStatfsCapacity.Reset()
+	o.SumStatUsedfiles.Reset()
+	o.SumStatStatfsFfree.Reset()
+	o.SumStatStatfsFiles.Reset()
+	o.DevStatStatfsFilled.Reset()
+	o.AvgStatStatfsFilled.Reset()
+	o.SigStatStatfsFilled.Reset()
+	o.CfgStatBalancing.Reset()
+	o.SumStatBalancerRunning.Reset()
+	o.SumStatDrainerRunning.Reset()
+
 	for _, m := range mds {
 
 		cfgstatus := 0
@@ -303,120 +329,100 @@ func (o *GroupCollector) collectGroupDF() error {
 		}
 
 		status := float64(cfgstatus)
-		o.CfgStatus.Reset()
 		o.CfgStatus.WithLabelValues(m.Name).Set(status)
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
-			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Name).Set(nofs)
 		}
 
 		avgdl, err := strconv.ParseFloat(m.AvgStatDiskLoad, 64)
 		if err == nil {
-			o.AvgStatDiskLoad.Reset()
 			o.AvgStatDiskLoad.WithLabelValues(m.Name).Set(avgdl)
 		}
 
 		sigdl, err := strconv.ParseFloat(m.SigStatDiskLoad, 64)
 		if err == nil {
-			o.SigStatDiskLoad.Reset()
 			o.SigStatDiskLoad.WithLabelValues(m.Name).Set(sigdl)
 		}
 
 		sumdiskr, err := strconv.ParseFloat(m.SumStatDiskReadratemb, 64)
 		if err == nil {
-			o.SumStatDiskReadratemb.Reset()
 			o.SumStatDiskReadratemb.WithLabelValues(m.Name).Set(sumdiskr)
 		}
 
 		sumdiskw, err := strconv.ParseFloat(m.SumStatDiskWriteratemb, 64)
 		if err == nil {
-			o.SumStatDiskWriteratemb.Reset()
 			o.SumStatDiskWriteratemb.WithLabelValues(m.Name).Set(sumdiskw)
 		}
 
 		sumethrate, err := strconv.ParseFloat(m.SumStatNetEthratemib, 64)
 		if err == nil {
-			o.SumStatNetEthratemib.Reset()
 			o.SumStatNetEthratemib.WithLabelValues(m.Name).Set(sumethrate)
 		}
 
 		suminrate, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
-			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Name).Set(suminrate)
 		}
 
 		sumoutrate, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
-			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Name).Set(sumoutrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
-			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Name).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
-			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Name).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.SumStatStatfsUsedbytes, 64)
 		if err == nil {
-			o.SumStatStatfsUsedbytes.Reset()
 			o.SumStatStatfsUsedbytes.WithLabelValues(m.Name).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFreebytes, 64)
 		if err == nil {
-			o.SumStatStatfsFreebytes.Reset()
 			o.SumStatStatfsFreebytes.WithLabelValues(m.Name).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.SumStatStatfsCapacity, 64)
 		if err == nil {
-			o.SumStatStatfsCapacity.Reset()
 			o.SumStatStatfsCapacity.WithLabelValues(m.Name).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatUsedfiles, 64)
 		if err == nil {
-			o.SumStatUsedfiles.Reset()
 			o.SumStatUsedfiles.WithLabelValues(m.Name).Set(ufiles)
 		}
 
 		ffree, err := strconv.ParseFloat(m.SumStatStatfsFfree, 64)
 		if err == nil {
-			o.SumStatStatfsFfree.Reset()
 			o.SumStatStatfsFfree.WithLabelValues(m.Name).Set(ffree)
 		}
 
 		files, err := strconv.ParseFloat(m.SumStatStatfsFiles, 64)
 		if err == nil {
-			o.SumStatStatfsFiles.Reset()
 			o.SumStatStatfsFiles.WithLabelValues(m.Name).Set(files)
 		}
 
 		devfilled, err := strconv.ParseFloat(m.DevStatStatfsFilled, 64)
 		if err == nil {
-			o.DevStatStatfsFilled.Reset()
 			o.DevStatStatfsFilled.WithLabelValues(m.Name).Set(devfilled)
 		}
 
 		avgfilled, err := strconv.ParseFloat(m.AvgStatStatfsFilled, 64)
 		if err == nil {
-			o.AvgStatStatfsFilled.Reset()
 			o.AvgStatStatfsFilled.WithLabelValues(m.Name).Set(avgfilled)
 		}
 
 		sigfilled, err := strconv.ParseFloat(m.SigStatStatfsFilled, 64)
 		if err == nil {
-			o.SigStatStatfsFilled.Reset()
 			o.SigStatStatfsFilled.WithLabelValues(m.Name).Set(sigfilled)
 		}
 
@@ -434,18 +440,15 @@ func (o *GroupCollector) collectGroupDF() error {
 			balancer_status = 0
 		}
 
-		o.CfgStatBalancing.Reset()
 		o.CfgStatBalancing.WithLabelValues(m.Name).Set(float64(balancer_status))
 
 		balr, err := strconv.ParseFloat(m.SumStatBalancerRunning, 64)
 		if err == nil {
-			o.SumStatBalancerRunning.Reset()
 			o.SumStatBalancerRunning.WithLabelValues(m.Name).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.SumStatDrainerRunning, 64)
 		if err == nil {
-			o.SumStatDrainerRunning.Reset()
 			o.SumStatDrainerRunning.WithLabelValues(m.Name).Set(drainr)
 		}
 	}

--- a/collector/group.go
+++ b/collector/group.go
@@ -36,7 +36,7 @@ type GroupCollector struct {
 	SumStatDrainerRunning  *prometheus.GaugeVec
 }
 
-//NewGroupCollector creates an cluster of the GroupCollector and instantiates
+// NewGroupCollector creates an cluster of the GroupCollector and instantiates
 // the individual metrics that show information about the Group.
 func NewGroupCollector(cluster string) *GroupCollector {
 	labels := make(prometheus.Labels)
@@ -303,100 +303,120 @@ func (o *GroupCollector) collectGroupDF() error {
 		}
 
 		status := float64(cfgstatus)
+		o.CfgStatus.Reset()
 		o.CfgStatus.WithLabelValues(m.Name).Set(status)
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
+			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Name).Set(nofs)
 		}
 
 		avgdl, err := strconv.ParseFloat(m.AvgStatDiskLoad, 64)
 		if err == nil {
+			o.AvgStatDiskLoad.Reset()
 			o.AvgStatDiskLoad.WithLabelValues(m.Name).Set(avgdl)
 		}
 
 		sigdl, err := strconv.ParseFloat(m.SigStatDiskLoad, 64)
 		if err == nil {
+			o.SigStatDiskLoad.Reset()
 			o.SigStatDiskLoad.WithLabelValues(m.Name).Set(sigdl)
 		}
 
 		sumdiskr, err := strconv.ParseFloat(m.SumStatDiskReadratemb, 64)
 		if err == nil {
+			o.SumStatDiskReadratemb.Reset()
 			o.SumStatDiskReadratemb.WithLabelValues(m.Name).Set(sumdiskr)
 		}
 
 		sumdiskw, err := strconv.ParseFloat(m.SumStatDiskWriteratemb, 64)
 		if err == nil {
+			o.SumStatDiskWriteratemb.Reset()
 			o.SumStatDiskWriteratemb.WithLabelValues(m.Name).Set(sumdiskw)
 		}
 
 		sumethrate, err := strconv.ParseFloat(m.SumStatNetEthratemib, 64)
 		if err == nil {
+			o.SumStatNetEthratemib.Reset()
 			o.SumStatNetEthratemib.WithLabelValues(m.Name).Set(sumethrate)
 		}
 
 		suminrate, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
+			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Name).Set(suminrate)
 		}
 
 		sumoutrate, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
+			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Name).Set(sumoutrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
+			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Name).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
+			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Name).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.SumStatStatfsUsedbytes, 64)
 		if err == nil {
+			o.SumStatStatfsUsedbytes.Reset()
 			o.SumStatStatfsUsedbytes.WithLabelValues(m.Name).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFreebytes, 64)
 		if err == nil {
+			o.SumStatStatfsFreebytes.Reset()
 			o.SumStatStatfsFreebytes.WithLabelValues(m.Name).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.SumStatStatfsCapacity, 64)
 		if err == nil {
+			o.SumStatStatfsCapacity.Reset()
 			o.SumStatStatfsCapacity.WithLabelValues(m.Name).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatUsedfiles, 64)
 		if err == nil {
+			o.SumStatUsedfiles.Reset()
 			o.SumStatUsedfiles.WithLabelValues(m.Name).Set(ufiles)
 		}
 
 		ffree, err := strconv.ParseFloat(m.SumStatStatfsFfree, 64)
 		if err == nil {
+			o.SumStatStatfsFfree.Reset()
 			o.SumStatStatfsFfree.WithLabelValues(m.Name).Set(ffree)
 		}
 
 		files, err := strconv.ParseFloat(m.SumStatStatfsFiles, 64)
 		if err == nil {
+			o.SumStatStatfsFiles.Reset()
 			o.SumStatStatfsFiles.WithLabelValues(m.Name).Set(files)
 		}
 
 		devfilled, err := strconv.ParseFloat(m.DevStatStatfsFilled, 64)
 		if err == nil {
+			o.DevStatStatfsFilled.Reset()
 			o.DevStatStatfsFilled.WithLabelValues(m.Name).Set(devfilled)
 		}
 
 		avgfilled, err := strconv.ParseFloat(m.AvgStatStatfsFilled, 64)
 		if err == nil {
+			o.AvgStatStatfsFilled.Reset()
 			o.AvgStatStatfsFilled.WithLabelValues(m.Name).Set(avgfilled)
 		}
 
 		sigfilled, err := strconv.ParseFloat(m.SigStatStatfsFilled, 64)
 		if err == nil {
+			o.SigStatStatfsFilled.Reset()
 			o.SigStatStatfsFilled.WithLabelValues(m.Name).Set(sigfilled)
 		}
 
@@ -414,15 +434,18 @@ func (o *GroupCollector) collectGroupDF() error {
 			balancer_status = 0
 		}
 
+		o.CfgStatBalancing.Reset()
 		o.CfgStatBalancing.WithLabelValues(m.Name).Set(float64(balancer_status))
 
 		balr, err := strconv.ParseFloat(m.SumStatBalancerRunning, 64)
 		if err == nil {
+			o.SumStatBalancerRunning.Reset()
 			o.SumStatBalancerRunning.WithLabelValues(m.Name).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.SumStatDrainerRunning, 64)
 		if err == nil {
+			o.SumStatDrainerRunning.Reset()
 			o.SumStatDrainerRunning.WithLabelValues(m.Name).Set(drainr)
 		}
 	}

--- a/collector/node.go
+++ b/collector/node.go
@@ -312,6 +312,7 @@ func (o *NodeCollector) collectNodeDF() error {
 			status = 0
 		}
 
+		o.Status.Reset()
 		o.Status.WithLabelValues(m.Host, m.Port).Set(float64(status))
 
 		// Config status: 1: on, 0: off
@@ -325,85 +326,102 @@ func (o *NodeCollector) collectNodeDF() error {
 			cfg_status = 0
 		}
 
+		o.CfgStatus.Reset()
 		o.CfgStatus.WithLabelValues(m.Host, m.Port).Set(float64(cfg_status))
 
 		heartbeatdelta, err := strconv.ParseFloat(m.HeartBeatDelta, 64)
 		if err == nil {
+			o.HeartBeatDelta.Reset()
 			o.HeartBeatDelta.WithLabelValues(m.Host, m.Port).Set(heartbeatdelta)
 		}
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
+			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Host, m.Port).Set(nofs)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFree, 64)
 		if err == nil {
+			o.SumStatStatfsFree.Reset()
 			o.SumStatStatfsFree.WithLabelValues(m.Host, m.Port).Set(fbytes)
 		}
 
 		ubytes, err := strconv.ParseFloat(m.SumStatStatfsUsed, 64)
 		if err == nil {
+			o.SumStatStatfsUsed.Reset()
 			o.SumStatStatfsUsed.WithLabelValues(m.Host, m.Port).Set(ubytes)
 		}
 
 		tbytes, err := strconv.ParseFloat(m.SumStatStatfsTotal, 64)
 		if err == nil {
+			o.SumStatStatfsTotal.Reset()
 			o.SumStatStatfsTotal.WithLabelValues(m.Host, m.Port).Set(tbytes)
 		}
 
 		ffiles, err := strconv.ParseFloat(m.SumStatStatFilesFree, 64)
 		if err == nil {
+			o.SumStatStatFilesFree.Reset()
 			o.SumStatStatFilesFree.WithLabelValues(m.Host, m.Port).Set(ffiles)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatStatFilesUsed, 64)
 		if err == nil {
+			o.SumStatStatFilesUsed.Reset()
 			o.SumStatStatFilesUsed.WithLabelValues(m.Host, m.Port).Set(ufiles)
 		}
 
 		tfiles, err := strconv.ParseFloat(m.SumStatStatFilesTotal, 64)
 		if err == nil {
+			o.SumStatStatFilesTotal.Reset()
 			o.SumStatStatFilesTotal.WithLabelValues(m.Host, m.Port).Set(tfiles)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
+			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Host, m.Port).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
+			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Host, m.Port).Set(wopen)
 		}
 
 		netin, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
+			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Host, m.Port).Set(netin)
 		}
 
 		netout, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
+			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Host, m.Port).Set(netout)
 		}
 
 		threads, err := strconv.ParseFloat(m.CfgStatSysThreads, 64)
 		if err == nil {
+			o.CfgStatSysThreads.Reset()
 			o.CfgStatSysThreads.WithLabelValues(m.Host, m.Port).Set(threads)
 		}
 
 		vsize, err := strconv.ParseFloat(m.CfgStatSysVsize, 64)
 		if err == nil {
+			o.CfgStatSysVsize.Reset()
 			o.CfgStatSysVsize.WithLabelValues(m.Host, m.Port).Set(vsize)
 		}
 
 		rss, err := strconv.ParseFloat(m.CfgStatSysRss, 64)
 		if err == nil {
+			o.CfgStatSysRss.Reset()
 			o.CfgStatSysRss.WithLabelValues(m.Host, m.Port).Set(rss)
 		}
 
 		sockets, err := strconv.ParseFloat(m.CfgStatSysSockets, 64)
 		if err == nil {
+			o.CfgStatSysSockets.Reset()
 			o.CfgStatSysSockets.WithLabelValues(m.Host, m.Port).Set(sockets)
 		}
 

--- a/collector/node.go
+++ b/collector/node.go
@@ -299,6 +299,28 @@ func (o *NodeCollector) collectNodeDF() error {
 		panic(err)
 	}
 
+	// Reset gauge metrics to remove metrics of removed nodes
+
+	o.Status.Reset()
+	o.CfgStatus.Reset()
+	o.Nofs.Reset()
+	o.HeartBeatDelta.Reset()
+	o.SumStatStatfsFree.Reset()
+	o.SumStatStatfsUsed.Reset()
+	o.SumStatStatfsTotal.Reset()
+	o.SumStatStatFilesFree.Reset()
+	o.SumStatStatFilesUsed.Reset()
+	o.SumStatStatFilesTotal.Reset()
+	o.SumStatRopen.Reset()
+	o.SumStatWopen.Reset()
+	o.CfgStatSysThreads.Reset()
+	o.CfgStatSysVsize.Reset()
+	o.CfgStatSysRss.Reset()
+	o.CfgStatSysSockets.Reset()
+	o.SumStatNetInratemib.Reset()
+	o.SumStatNetOutratemib.Reset()
+	o.Info.Reset()
+
 	for _, m := range mds {
 
 		// Status: 1: online, 0: offline
@@ -312,7 +334,6 @@ func (o *NodeCollector) collectNodeDF() error {
 			status = 0
 		}
 
-		o.Status.Reset()
 		o.Status.WithLabelValues(m.Host, m.Port).Set(float64(status))
 
 		// Config status: 1: on, 0: off
@@ -326,106 +347,90 @@ func (o *NodeCollector) collectNodeDF() error {
 			cfg_status = 0
 		}
 
-		o.CfgStatus.Reset()
 		o.CfgStatus.WithLabelValues(m.Host, m.Port).Set(float64(cfg_status))
 
 		heartbeatdelta, err := strconv.ParseFloat(m.HeartBeatDelta, 64)
 		if err == nil {
-			o.HeartBeatDelta.Reset()
 			o.HeartBeatDelta.WithLabelValues(m.Host, m.Port).Set(heartbeatdelta)
 		}
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
-			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Host, m.Port).Set(nofs)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFree, 64)
 		if err == nil {
-			o.SumStatStatfsFree.Reset()
 			o.SumStatStatfsFree.WithLabelValues(m.Host, m.Port).Set(fbytes)
 		}
 
 		ubytes, err := strconv.ParseFloat(m.SumStatStatfsUsed, 64)
 		if err == nil {
-			o.SumStatStatfsUsed.Reset()
 			o.SumStatStatfsUsed.WithLabelValues(m.Host, m.Port).Set(ubytes)
 		}
 
 		tbytes, err := strconv.ParseFloat(m.SumStatStatfsTotal, 64)
 		if err == nil {
-			o.SumStatStatfsTotal.Reset()
 			o.SumStatStatfsTotal.WithLabelValues(m.Host, m.Port).Set(tbytes)
 		}
 
 		ffiles, err := strconv.ParseFloat(m.SumStatStatFilesFree, 64)
 		if err == nil {
-			o.SumStatStatFilesFree.Reset()
 			o.SumStatStatFilesFree.WithLabelValues(m.Host, m.Port).Set(ffiles)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatStatFilesUsed, 64)
 		if err == nil {
-			o.SumStatStatFilesUsed.Reset()
 			o.SumStatStatFilesUsed.WithLabelValues(m.Host, m.Port).Set(ufiles)
 		}
 
 		tfiles, err := strconv.ParseFloat(m.SumStatStatFilesTotal, 64)
 		if err == nil {
-			o.SumStatStatFilesTotal.Reset()
 			o.SumStatStatFilesTotal.WithLabelValues(m.Host, m.Port).Set(tfiles)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
-			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Host, m.Port).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
-			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Host, m.Port).Set(wopen)
 		}
 
 		netin, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
-			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Host, m.Port).Set(netin)
 		}
 
 		netout, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
-			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Host, m.Port).Set(netout)
 		}
 
 		threads, err := strconv.ParseFloat(m.CfgStatSysThreads, 64)
 		if err == nil {
-			o.CfgStatSysThreads.Reset()
 			o.CfgStatSysThreads.WithLabelValues(m.Host, m.Port).Set(threads)
 		}
 
 		vsize, err := strconv.ParseFloat(m.CfgStatSysVsize, 64)
 		if err == nil {
-			o.CfgStatSysVsize.Reset()
 			o.CfgStatSysVsize.WithLabelValues(m.Host, m.Port).Set(vsize)
 		}
 
 		rss, err := strconv.ParseFloat(m.CfgStatSysRss, 64)
 		if err == nil {
-			o.CfgStatSysRss.Reset()
 			o.CfgStatSysRss.WithLabelValues(m.Host, m.Port).Set(rss)
 		}
 
 		sockets, err := strconv.ParseFloat(m.CfgStatSysSockets, 64)
 		if err == nil {
-			o.CfgStatSysSockets.Reset()
 			o.CfgStatSysSockets.WithLabelValues(m.Host, m.Port).Set(sockets)
 		}
 
 		// We send just a dummy 1 as value for the eos_node_info metric, and metadata on labels
+		o.Info.WithLabelValues(m.Host, m.Port, m.EOSVersion, m.XRootDVersion, m.Kernel, m.Geotag).Set(1)
 		o.Info.WithLabelValues(m.Host, m.Port, m.EOSVersion, m.XRootDVersion, m.Kernel, m.Geotag).Set(1)
 	}
 

--- a/collector/space.go
+++ b/collector/space.go
@@ -10,36 +10,36 @@ import (
 )
 
 /*
-type=spaceview 
-name=default 
-cfg.groupsize=11 
-cfg.groupmod=50 
-nofs=337 
-avg.stat.disk.load=0.27 
-sig.stat.disk.load=0.38 
-sum.stat.disk.readratemb=4481 
-sum.stat.disk.writeratemb=39 
-sum.stat.net.ethratemib=13708 
-sum.stat.net.inratemib=32 
-sum.stat.net.outratemib=32 
-sum.stat.ropen=72 
-sum.stat.wopen=77 
-sum.stat.statfs.usedbytes=1442925699514368 
-sum.stat.statfs.freebytes=1630645688213504 
-sum.stat.statfs.freebytes?configstatus@rw=1624647716261888 
-sum.stat.statfs.capacity=3073571387727872 
-sum.stat.usedfiles=386144110 
-sum.stat.statfs.ffiles=0 
-sum.stat.statfs.files=150111401344 
-sched.capacity=1617927719616512 
-sum.stat.statfs.capacity?configstatus@rw=3060852351262720 
-sum.<n>?configstatus@rw=336 
-cfg.quota=on 
-cfg.nominalsize=??? 
+type=spaceview
+name=default
+cfg.groupsize=11
+cfg.groupmod=50
+nofs=337
+avg.stat.disk.load=0.27
+sig.stat.disk.load=0.38
+sum.stat.disk.readratemb=4481
+sum.stat.disk.writeratemb=39
+sum.stat.net.ethratemib=13708
+sum.stat.net.inratemib=32
+sum.stat.net.outratemib=32
+sum.stat.ropen=72
+sum.stat.wopen=77
+sum.stat.statfs.usedbytes=1442925699514368
+sum.stat.statfs.freebytes=1630645688213504
+sum.stat.statfs.freebytes?configstatus@rw=1624647716261888
+sum.stat.statfs.capacity=3073571387727872
+sum.stat.usedfiles=386144110
+sum.stat.statfs.ffiles=0
+sum.stat.statfs.files=150111401344
+sched.capacity=1617927719616512
+sum.stat.statfs.capacity?configstatus@rw=3060852351262720
+sum.<n>?configstatus@rw=336
+cfg.quota=on
+cfg.nominalsize=???
 cfg.balancer=on
-cfg.balancer.threshold=20 
-sum.stat.balancer.running=19 
-sum.stat.disk.iops?configstatus@rw=22960 
+cfg.balancer.threshold=20
+sum.stat.balancer.running=19
+sum.stat.disk.iops?configstatus@rw=22960
 sum.stat.disk.bw?configstatus@rw=63069
 */
 
@@ -75,7 +75,7 @@ type SpaceCollector struct {
 	SumStatStatfsFreebytesConfigstatusRw *prometheus.GaugeVec
 }
 
-//NewSpaceCollector creates an cluster of the SpaceCollector
+// NewSpaceCollector creates an cluster of the SpaceCollector
 func NewSpaceCollector(cluster string) *SpaceCollector {
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
@@ -400,106 +400,127 @@ func (o *SpaceCollector) collectSpaceDF() error {
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
+			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Name).Set(nofs)
 		}
 
 		avgdl, err := strconv.ParseFloat(m.AvgStatDiskLoad, 64)
 		if err == nil {
+			o.AvgStatDiskLoad.Reset()
 			o.AvgStatDiskLoad.WithLabelValues(m.Name).Set(avgdl)
 		}
 
 		sigdl, err := strconv.ParseFloat(m.SigStatDiskLoad, 64)
 		if err == nil {
+			o.SigStatDiskLoad.Reset()
 			o.SigStatDiskLoad.WithLabelValues(m.Name).Set(sigdl)
 		}
 
 		sumdiskr, err := strconv.ParseFloat(m.SumStatDiskReadratemb, 64)
 		if err == nil {
+			o.SumStatDiskReadratemb.Reset()
 			o.SumStatDiskReadratemb.WithLabelValues(m.Name).Set(sumdiskr)
 		}
 
 		sumdiskw, err := strconv.ParseFloat(m.SumStatDiskWriteratemb, 64)
 		if err == nil {
+			o.SumStatDiskWriteratemb.Reset()
 			o.SumStatDiskWriteratemb.WithLabelValues(m.Name).Set(sumdiskw)
 		}
 
 		sumethrate, err := strconv.ParseFloat(m.SumStatNetEthratemib, 64)
 		if err == nil {
+			o.SumStatNetEthratemib.Reset()
 			o.SumStatNetEthratemib.WithLabelValues(m.Name).Set(sumethrate)
 		}
 
 		suminrate, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
+			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Name).Set(suminrate)
 		}
 
 		sumoutrate, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
+			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Name).Set(sumoutrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
+			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Name).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
+			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Name).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.SumStatStatfsUsedbytes, 64)
 		if err == nil {
+			o.SumStatStatfsUsedbytes.Reset()
 			o.SumStatStatfsUsedbytes.WithLabelValues(m.Name).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFreebytes, 64)
 		if err == nil {
+			o.SumStatStatfsFreebytes.Reset()
 			o.SumStatStatfsFreebytes.WithLabelValues(m.Name).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.SumStatStatfsCapacity, 64)
 		if err == nil {
+			o.SumStatStatfsCapacity.Reset()
 			o.SumStatStatfsCapacity.WithLabelValues(m.Name).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatUsedfiles, 64)
 		if err == nil {
+			o.SumStatUsedfiles.Reset()
 			o.SumStatUsedfiles.WithLabelValues(m.Name).Set(ufiles)
 		}
 
 		files, err := strconv.ParseFloat(m.SumStatStatfsFiles, 64)
 		if err == nil {
+			o.SumStatStatfsFiles.Reset()
 			o.SumStatStatfsFiles.WithLabelValues(m.Name).Set(files)
 		}
 
 		caprw, err := strconv.ParseFloat(m.SumStatStatfsCapacityConfigstatusRw, 64)
 		if err == nil {
+			o.SumStatStatfsCapacityConfigstatusRw.Reset()
 			o.SumStatStatfsCapacityConfigstatusRw.WithLabelValues(m.Name).Set(caprw)
 		}
 
 		nofsrw, err := strconv.ParseFloat(m.SumNofsConfigstatusRw, 64)
 		if err == nil {
+			o.SumNofsConfigstatusRw.Reset()
 			o.SumNofsConfigstatusRw.WithLabelValues(m.Name).Set(nofsrw)
 		}
 
 		balr, err := strconv.ParseFloat(m.SumStatBalancerRunning, 64)
 		if err == nil {
+			o.SumStatBalancerRunning.Reset()
 			o.SumStatBalancerRunning.WithLabelValues(m.Name).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.SumStatDrainerRunning, 64)
 		if err == nil {
+			o.SumStatDrainerRunning.Reset()
 			o.SumStatDrainerRunning.WithLabelValues(m.Name).Set(drainr)
 		}
 
 		iopsrw, err := strconv.ParseFloat(m.SumStatDiskIopsConfigstatusRw, 64)
 		if err == nil {
+			o.SumStatDiskIopsConfigstatusRw.Reset()
 			o.SumStatDiskIopsConfigstatusRw.WithLabelValues(m.Name).Set(iopsrw)
 		}
 
 		bwrw, err := strconv.ParseFloat(m.SumStatDiskBwConfigstatusRw, 64)
 		if err == nil {
+			o.SumStatDiskBwConfigstatusRw.Reset()
 			o.SumStatDiskBwConfigstatusRw.WithLabelValues(m.Name).Set(bwrw)
 		}
 
@@ -513,20 +534,24 @@ func (o *SpaceCollector) collectSpaceDF() error {
 			balancer_status = 0
 		}
 
+		o.CfgBalancer.Reset()
 		o.CfgBalancer.WithLabelValues(m.Name).Set(float64(balancer_status))
 
 		balt, err := strconv.ParseFloat(m.CfgBalancerThreshold, 64)
 		if err == nil {
+			o.CfgBalancerThreshold.Reset()
 			o.CfgBalancerThreshold.WithLabelValues(m.Name).Set(balt)
 		}
 
 		gsize, err := strconv.ParseFloat(m.CfgGroupSize, 64)
 		if err == nil {
+			o.CfgGroupSize.Reset()
 			o.CfgGroupSize.WithLabelValues(m.Name).Set(gsize)
 		}
 
 		gmod, err := strconv.ParseFloat(m.CfgGroupMod, 64)
 		if err == nil {
+			o.CfgGroupMod.Reset()
 			o.CfgGroupMod.WithLabelValues(m.Name).Set(gmod)
 		}
 
@@ -540,10 +565,11 @@ func (o *SpaceCollector) collectSpaceDF() error {
 			quota_status = 0
 		}
 
+		o.CfgQuota.Reset()
 		o.CfgQuota.WithLabelValues(m.Name).Set(float64(quota_status))
 
-		// convert nominal size 0 if not defined. 
-
+		// convert nominal size 0 if not defined.
+		o.CfgNominalsize.Reset()
 		if m.CfgNominalsize != "???" {
 			nomsize, err := strconv.ParseFloat(m.CfgNominalsize, 64)
 			if err == nil {
@@ -551,10 +577,11 @@ func (o *SpaceCollector) collectSpaceDF() error {
 			}
 		} else {
 			o.CfgNominalsize.WithLabelValues(m.Name).Set(0)
-		} 
-		
+		}
+
 		fbytesRW, err := strconv.ParseFloat(m.SumStatStatfsFreebytesConfigstatusRw, 64)
 		if err == nil {
+			o.SumStatStatfsFreebytesConfigstatusRw.Reset()
 			o.SumStatStatfsFreebytesConfigstatusRw.WithLabelValues(m.Name).Set(fbytesRW)
 		}
 

--- a/collector/space.go
+++ b/collector/space.go
@@ -396,131 +396,142 @@ func (o *SpaceCollector) collectSpaceDF() error {
 		panic(err)
 	}
 
+	// reset gauges (to drop metrics of deleted spaces)
+
+	o.CfgGroupSize.Reset()
+	o.CfgGroupMod.Reset()
+	o.Nofs.Reset()
+	o.AvgStatDiskLoad.Reset()
+	o.SigStatDiskLoad.Reset()
+	o.SumStatDiskReadratemb.Reset()
+	o.SumStatDiskWriteratemb.Reset()
+	o.SumStatNetEthratemib.Reset()
+	o.SumStatNetInratemib.Reset()
+	o.SumStatNetOutratemib.Reset()
+	o.SumStatRopen.Reset()
+	o.SumStatWopen.Reset()
+	o.SumStatStatfsUsedbytes.Reset()
+	o.SumStatStatfsFreebytes.Reset()
+	o.SumStatStatfsCapacity.Reset()
+	o.SumStatUsedfiles.Reset()
+	o.SumStatStatfsFfiles.Reset()
+	o.SumStatStatfsFiles.Reset()
+	o.SumStatStatfsCapacityConfigstatusRw.Reset()
+	o.SumNofsConfigstatusRw.Reset()
+	o.CfgQuota.Reset()
+	o.CfgNominalsize.Reset()
+	o.CfgBalancer.Reset()
+	o.CfgBalancerThreshold.Reset()
+	o.SumStatBalancerRunning.Reset()
+	o.SumStatDrainerRunning.Reset()
+	o.SumStatDiskIopsConfigstatusRw.Reset()
+	o.SumStatDiskBwConfigstatusRw.Reset()
+	o.SumStatStatfsFreebytesConfigstatusRw.Reset()
+
 	for _, m := range mds {
 
 		nofs, err := strconv.ParseFloat(m.Nofs, 64)
 		if err == nil {
-			o.Nofs.Reset()
 			o.Nofs.WithLabelValues(m.Name).Set(nofs)
 		}
 
 		avgdl, err := strconv.ParseFloat(m.AvgStatDiskLoad, 64)
 		if err == nil {
-			o.AvgStatDiskLoad.Reset()
 			o.AvgStatDiskLoad.WithLabelValues(m.Name).Set(avgdl)
 		}
 
 		sigdl, err := strconv.ParseFloat(m.SigStatDiskLoad, 64)
 		if err == nil {
-			o.SigStatDiskLoad.Reset()
 			o.SigStatDiskLoad.WithLabelValues(m.Name).Set(sigdl)
 		}
 
 		sumdiskr, err := strconv.ParseFloat(m.SumStatDiskReadratemb, 64)
 		if err == nil {
-			o.SumStatDiskReadratemb.Reset()
 			o.SumStatDiskReadratemb.WithLabelValues(m.Name).Set(sumdiskr)
 		}
 
 		sumdiskw, err := strconv.ParseFloat(m.SumStatDiskWriteratemb, 64)
 		if err == nil {
-			o.SumStatDiskWriteratemb.Reset()
 			o.SumStatDiskWriteratemb.WithLabelValues(m.Name).Set(sumdiskw)
 		}
 
 		sumethrate, err := strconv.ParseFloat(m.SumStatNetEthratemib, 64)
 		if err == nil {
-			o.SumStatNetEthratemib.Reset()
 			o.SumStatNetEthratemib.WithLabelValues(m.Name).Set(sumethrate)
 		}
 
 		suminrate, err := strconv.ParseFloat(m.SumStatNetInratemib, 64)
 		if err == nil {
-			o.SumStatNetInratemib.Reset()
 			o.SumStatNetInratemib.WithLabelValues(m.Name).Set(suminrate)
 		}
 
 		sumoutrate, err := strconv.ParseFloat(m.SumStatNetOutratemib, 64)
 		if err == nil {
-			o.SumStatNetOutratemib.Reset()
 			o.SumStatNetOutratemib.WithLabelValues(m.Name).Set(sumoutrate)
 		}
 
 		ropen, err := strconv.ParseFloat(m.SumStatRopen, 64)
 		if err == nil {
-			o.SumStatRopen.Reset()
 			o.SumStatRopen.WithLabelValues(m.Name).Set(ropen)
 		}
 
 		wopen, err := strconv.ParseFloat(m.SumStatWopen, 64)
 		if err == nil {
-			o.SumStatWopen.Reset()
 			o.SumStatWopen.WithLabelValues(m.Name).Set(wopen)
 		}
 
 		usedb, err := strconv.ParseFloat(m.SumStatStatfsUsedbytes, 64)
 		if err == nil {
-			o.SumStatStatfsUsedbytes.Reset()
 			o.SumStatStatfsUsedbytes.WithLabelValues(m.Name).Set(usedb)
 		}
 
 		fbytes, err := strconv.ParseFloat(m.SumStatStatfsFreebytes, 64)
 		if err == nil {
-			o.SumStatStatfsFreebytes.Reset()
 			o.SumStatStatfsFreebytes.WithLabelValues(m.Name).Set(fbytes)
 		}
 
 		fscap, err := strconv.ParseFloat(m.SumStatStatfsCapacity, 64)
 		if err == nil {
-			o.SumStatStatfsCapacity.Reset()
 			o.SumStatStatfsCapacity.WithLabelValues(m.Name).Set(fscap)
 		}
 
 		ufiles, err := strconv.ParseFloat(m.SumStatUsedfiles, 64)
 		if err == nil {
-			o.SumStatUsedfiles.Reset()
 			o.SumStatUsedfiles.WithLabelValues(m.Name).Set(ufiles)
 		}
 
 		files, err := strconv.ParseFloat(m.SumStatStatfsFiles, 64)
 		if err == nil {
-			o.SumStatStatfsFiles.Reset()
 			o.SumStatStatfsFiles.WithLabelValues(m.Name).Set(files)
 		}
 
 		caprw, err := strconv.ParseFloat(m.SumStatStatfsCapacityConfigstatusRw, 64)
 		if err == nil {
-			o.SumStatStatfsCapacityConfigstatusRw.Reset()
 			o.SumStatStatfsCapacityConfigstatusRw.WithLabelValues(m.Name).Set(caprw)
 		}
 
 		nofsrw, err := strconv.ParseFloat(m.SumNofsConfigstatusRw, 64)
 		if err == nil {
-			o.SumNofsConfigstatusRw.Reset()
 			o.SumNofsConfigstatusRw.WithLabelValues(m.Name).Set(nofsrw)
 		}
 
 		balr, err := strconv.ParseFloat(m.SumStatBalancerRunning, 64)
 		if err == nil {
-			o.SumStatBalancerRunning.Reset()
 			o.SumStatBalancerRunning.WithLabelValues(m.Name).Set(balr)
 		}
 
 		drainr, err := strconv.ParseFloat(m.SumStatDrainerRunning, 64)
 		if err == nil {
-			o.SumStatDrainerRunning.Reset()
 			o.SumStatDrainerRunning.WithLabelValues(m.Name).Set(drainr)
 		}
 
 		iopsrw, err := strconv.ParseFloat(m.SumStatDiskIopsConfigstatusRw, 64)
 		if err == nil {
-			o.SumStatDiskIopsConfigstatusRw.Reset()
 			o.SumStatDiskIopsConfigstatusRw.WithLabelValues(m.Name).Set(iopsrw)
 		}
 
 		bwrw, err := strconv.ParseFloat(m.SumStatDiskBwConfigstatusRw, 64)
 		if err == nil {
-			o.SumStatDiskBwConfigstatusRw.Reset()
 			o.SumStatDiskBwConfigstatusRw.WithLabelValues(m.Name).Set(bwrw)
 		}
 
@@ -534,24 +545,20 @@ func (o *SpaceCollector) collectSpaceDF() error {
 			balancer_status = 0
 		}
 
-		o.CfgBalancer.Reset()
 		o.CfgBalancer.WithLabelValues(m.Name).Set(float64(balancer_status))
 
 		balt, err := strconv.ParseFloat(m.CfgBalancerThreshold, 64)
 		if err == nil {
-			o.CfgBalancerThreshold.Reset()
 			o.CfgBalancerThreshold.WithLabelValues(m.Name).Set(balt)
 		}
 
 		gsize, err := strconv.ParseFloat(m.CfgGroupSize, 64)
 		if err == nil {
-			o.CfgGroupSize.Reset()
 			o.CfgGroupSize.WithLabelValues(m.Name).Set(gsize)
 		}
 
 		gmod, err := strconv.ParseFloat(m.CfgGroupMod, 64)
 		if err == nil {
-			o.CfgGroupMod.Reset()
 			o.CfgGroupMod.WithLabelValues(m.Name).Set(gmod)
 		}
 
@@ -565,11 +572,9 @@ func (o *SpaceCollector) collectSpaceDF() error {
 			quota_status = 0
 		}
 
-		o.CfgQuota.Reset()
 		o.CfgQuota.WithLabelValues(m.Name).Set(float64(quota_status))
 
 		// convert nominal size 0 if not defined.
-		o.CfgNominalsize.Reset()
 		if m.CfgNominalsize != "???" {
 			nomsize, err := strconv.ParseFloat(m.CfgNominalsize, 64)
 			if err == nil {
@@ -581,7 +586,6 @@ func (o *SpaceCollector) collectSpaceDF() error {
 
 		fbytesRW, err := strconv.ParseFloat(m.SumStatStatfsFreebytesConfigstatusRw, 64)
 		if err == nil {
-			o.SumStatStatfsFreebytesConfigstatusRw.Reset()
 			o.SumStatStatfsFreebytesConfigstatusRw.WithLabelValues(m.Name).Set(fbytesRW)
 		}
 


### PR DESCRIPTION
Now gauge metrics are reset during each collection. Avoids reporting series that are not there anymore,e.g, when a filesystem is removed or re-created. Before, metrics of non-existent filesystems were still reported until a restart of the exporter. 