### PR TITLE
add fusex client information collector - closes #26

### DIFF
--- a/collector/fusex.go
+++ b/collector/fusex.go
@@ -1,0 +1,132 @@
+package collector
+
+import (
+	"context"
+	"log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.cern.ch/rvalverd/eos_exporter/eosclient"
+)
+
+// sample line
+/*
+client=eosxd
+host=hostname
+version=4.8.28
+state=online
+time="Fri, 25 Mar 2022 15:31:45 GMT"
+tof=4.22
+delta=0.18
+uuid=ad7a6d7a-ac50-11ec-8090-fa163e4b8280
+pid=6271
+caps=0
+fds=0
+type=static
+mount="/eos/home-i00/"
+app=
+ino=1
+ino-to-del=0
+ino-backlog=0
+ino-ever=1
+ino-ever-del=0
+threads=26
+total-ram-gb=14.989
+free-ram-gb=3.933
+vsize-gb=0.417
+rsize-gb=0.021
+wr-buf-mb=0
+ra-buf-mb=0
+load1=0.19
+leasetime=300
+open-files=0
+logfile-size=15332
+rbytes=0
+wbytes=0
+n-op=0
+rd60-rate-mb=0.00
+wr60-rate-mb=0.00
+iops60=0.00
+xoff=0
+ra-xoff=0
+ra-nobuf=0
+wr-nobuf=0
+idle=4
+recovery-ok=0
+recovery-fail=0
+blockedms=0.000000
+blockedfunc=none
+*/
+
+type FusexCollector struct {
+	Info *prometheus.GaugeVec
+}
+
+// NewFSCollector creates an cluster of the FSCollector and instantiates
+// the individual metrics that show information about the FS.
+func NewFusexCollector(cluster string) *FusexCollector {
+	labels := make(prometheus.Labels)
+	labels["cluster"] = cluster
+	namespace := "eos"
+	return &FusexCollector{
+		Info: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "fusex_info",
+				Help:        "fusex mount information",
+				ConstLabels: labels,
+			},
+			[]string{"host", "version"},
+		),
+	}
+}
+
+func (o *FusexCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		o.Info,
+	}
+}
+
+func (o *FusexCollector) collectFusexDF() error {
+	ins := getEOSInstance()
+	url := "root://" + ins
+	opt := &eosclient.Options{URL: url}
+	client, err := eosclient.New(opt)
+	if err != nil {
+		panic(err)
+	}
+
+	mds, err := client.ListFusex(context.Background(), "root")
+	if err != nil {
+		panic(err)
+	}
+
+	o.Info.Reset()
+
+	for _, m := range mds {
+		// We just send a dummy 1 as value
+		o.Info.WithLabelValues(m.Host, m.Version).Set(1)
+	}
+
+	return nil
+
+} // collectFusexDF()
+
+// Describe sends the descriptors of each FSCollector related metrics we have defined
+func (o *FusexCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range o.collectorList() {
+		metric.Describe(ch)
+	}
+	//ch <- o.ScrubbingStateDesc
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+func (o *FusexCollector) Collect(ch chan<- prometheus.Metric) {
+
+	if err := o.collectFusexDF(); err != nil {
+		log.Println("failed collecting fsck metrics:", err)
+	}
+
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/eos_exporter.go
+++ b/eos_exporter.go
@@ -73,6 +73,7 @@ func NewEOSExporter(instance string) *EOSExporter {
 			collector.NewRecycleCollector(instance),    // eos recycle bin information
 			collector.NewWhoCollector(instance),        // eos who information
 			collector.NewFsckCollector(instance),       // eos fsck information
+			collector.NewFusexCollector(instance),      // eos fusex information
 		},
 	}
 }


### PR DESCRIPTION
Added fusex collector. For now, only the following metric is added.
`eos_fusex_info{host=, version=}`