### PR TITLE
add eos inspector collector - Closes #24

### DIFF
--- a/collector/inspector.go
+++ b/collector/inspector.go
@@ -1,0 +1,87 @@
+package collector
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gitlab.cern.ch/rvalverd/eos_exporter/eosclient"
+)
+
+type InspectorLayoutCollector struct {
+	Volume *prometheus.GaugeVec
+}
+
+// NewFSCollector creates an cluster of the FSCollector and instantiates
+// the individual metrics that show information about the FS.
+func NewInspectorLayoutCollector(cluster string) *InspectorLayoutCollector {
+	labels := make(prometheus.Labels)
+	labels["cluster"] = cluster
+	namespace := "eos"
+	return &InspectorLayoutCollector{
+		Volume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "inspector_layout_volume_bytes",
+				Help:        "volume per layout in bytes",
+				ConstLabels: labels,
+			},
+			[]string{"layout", "type", "nominal_stripes", "blocksize"},
+		),
+	}
+}
+
+func (o *InspectorLayoutCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		o.Volume,
+	}
+}
+
+func (o *InspectorLayoutCollector) collectInspectorLayoutDF() error {
+	ins := getEOSInstance()
+	url := "root://" + ins
+	opt := &eosclient.Options{URL: url}
+	client, err := eosclient.New(opt)
+	if err != nil {
+		panic(err)
+	}
+
+	mds, err := client.ListInspectorLayout(context.Background(), "root")
+	if err != nil {
+		panic(err)
+	}
+
+	o.Volume.Reset()
+
+	for _, m := range mds {
+
+		volume, err := strconv.ParseFloat(m.Volume, 64)
+		if err == nil {
+			o.Volume.WithLabelValues(m.Layout, m.Type, m.NominalStripes, m.BlockSize).Set(volume)
+		}
+	}
+
+	return nil
+
+} // collectInspectorLayoutDF()
+
+// Describe sends the descriptors of each FSCollector related metrics we have defined
+func (o *InspectorLayoutCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range o.collectorList() {
+		metric.Describe(ch)
+	}
+	//ch <- o.ScrubbingStateDesc
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+func (o *InspectorLayoutCollector) Collect(ch chan<- prometheus.Metric) {
+
+	if err := o.collectInspectorLayoutDF(); err != nil {
+		log.Println("failed collecting eos inspector metrics:", err)
+	}
+
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/eos_exporter.go
+++ b/eos_exporter.go
@@ -61,19 +61,20 @@ var _ prometheus.Collector = &EOSExporter{}
 func NewEOSExporter(instance string) *EOSExporter {
 	return &EOSExporter{
 		collectors: []prometheus.Collector{
-			collector.NewSpaceCollector(instance),      // eos space stats
-			collector.NewGroupCollector(instance),      // eos scheduling group stats
-			collector.NewNodeCollector(instance),       // eos node stats
-			collector.NewFSCollector(instance),         // eos filesystem stats
-			collector.NewIOInfoCollector(instance),     // eos io stat information
-			collector.NewIOAppInfoCollector(instance),  // eos io stat information per App
-			collector.NewNSCollector(instance),         // eos namespace information
-			collector.NewNSActivityCollector(instance), // eos namespace activity information
-			collector.NewNSBatchCollector(instance),    // eos namespace potential batch overload information
-			collector.NewRecycleCollector(instance),    // eos recycle bin information
-			collector.NewWhoCollector(instance),        // eos who information
-			collector.NewFsckCollector(instance),       // eos fsck information
-			collector.NewFusexCollector(instance),      // eos fusex information
+			collector.NewSpaceCollector(instance),           // eos space stats
+			collector.NewGroupCollector(instance),           // eos scheduling group stats
+			collector.NewNodeCollector(instance),            // eos node stats
+			collector.NewFSCollector(instance),              // eos filesystem stats
+			collector.NewIOInfoCollector(instance),          // eos io stat information
+			collector.NewIOAppInfoCollector(instance),       // eos io stat information per App
+			collector.NewNSCollector(instance),              // eos namespace information
+			collector.NewNSActivityCollector(instance),      // eos namespace activity information
+			collector.NewNSBatchCollector(instance),         // eos namespace potential batch overload information
+			collector.NewRecycleCollector(instance),         // eos recycle bin information
+			collector.NewWhoCollector(instance),             // eos who information
+			collector.NewFsckCollector(instance),            // eos fsck information
+			collector.NewFusexCollector(instance),           // eos fusex information
+			collector.NewInspectorLayoutCollector(instance), // eos inspector layout information
 		},
 	}
 }


### PR DESCRIPTION
Adds a  new metric which shows volume per layout, gathered from `eos inspector -m command`. e, g: 
```
eos_inspector_layout_volume{layout="00000000", type="plain", nominal_stripes="1", blocksize="4k"} 78670882614
```