### PR TITLE
Increase timeouts to 30 seconds

### DIFF
--- a/eosclient/eos.go
+++ b/eosclient/eos.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var cmdTimeout = 10 * time.Second // Time-out for the EOS commands
+var cmdTimeout = 30 * time.Second // Time-out for the EOS commands
 
 type Options struct {
 	// Location of the eos binary. Default is /usr/bin/eos.


### PR DESCRIPTION
As seen recently in CMS instance when running `eos space ls`.

```
2022-11-20T17:22:40.073040+01:00 eoscms-ns-ip563.cern.ch eos_exporter: panic: signal: killed
2022-11-20T17:22:40.073293+01:00 eoscms-ns-ip563.cern.ch eos_exporter: goroutine 91494 [running]:
2022-11-20T17:22:40.073437+01:00 eoscms-ns-ip563.cern.ch eos_exporter: gitlab.cern.ch/rvalverd/eos_exporter/collector.(*RecycleCollector).collectRecycleDF(0xc0001e2080, 0x4, 0xc0128d1ea8)
2022-11-20T17:22:40.073576+01:00 eoscms-ns-ip563.cern.ch eos_exporter: /builds/rvalverd/eos_exporter/collector/recycle.go:91 +0x417
2022-11-20T17:22:40.073719+01:00 eoscms-ns-ip563.cern.ch eos_exporter: gitlab.cern.ch/rvalverd/eos_exporter/collector.(*RecycleCollector).Collect(0xc0001e2080, 0xc00049a840)
2022-11-20T17:22:40.073854+01:00 eoscms-ns-ip563.cern.ch eos_exporter: /builds/rvalverd/eos_exporter/collector/recycle.go:131 +0x45
2022-11-20T17:22:40.074017+01:00 eoscms-ns-ip563.cern.ch eos_exporter: main.(*EOSExporter).Collect(0xc0001e0720, 0xc00049a840)
2022-11-20T17:22:40.074153+01:00 eoscms-ns-ip563.cern.ch eos_exporter: /builds/rvalverd/eos_exporter/eos_exporter.go:93 +0xa8
2022-11-20T17:22:40.074292+01:00 eoscms-ns-ip563.cern.ch eos_exporter: github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
2022-11-20T17:22:40.074432+01:00 eoscms-ns-ip563.cern.ch eos_exporter: /root/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:446 +0x12b
2022-11-20T17:22:40.074569+01:00 eoscms-ns-ip563.cern.ch eos_exporter: created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
2022-11-20T17:22:40.074720+01:00 eoscms-ns-ip563.cern.ch eos_exporter: /root/go/pkg/mod/github.com/prometheus/client_golang@v1.12.2/prometheus/registry.go:538 +0xe4d
2022-11-20T17:22:40.336648+01:00 eoscms-ns-ip563.cern.ch eos_exporter: Starting eos exporter for instance: eoscms at &{0xc0001e0360}&{0xc0001e0420}&{0xc0001e04e0}&{0xc0001e05a0}&{0xc0001e0690}2022/11/20 17:22:40 Listening on :9986
```