### PR TITLE
Do not panic when getting metrics and add custom timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ descr:
 	@echo "You are building the EOS exporter binary."
 
 build:
+	./get_build_info.sh
 	go generate
 	go build .
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,0 +1,6 @@
+package collector
+
+type CollectorOpts struct {
+	Cluster string
+	Timeout int
+}

--- a/collector/fs.go
+++ b/collector/fs.go
@@ -396,7 +396,7 @@ func (o *FSCollector) collectFSDF() error {
 
 	mds, err := client.ListFS(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Reset Gauge metrics to remove metrics of non existing filesystems
@@ -632,6 +632,7 @@ func (o *FSCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectFSDF(); err != nil {
 		log.Println("failed collecting fs metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/fs.go
+++ b/collector/fs.go
@@ -14,6 +14,7 @@ import (
 )
 
 type FSCollector struct {
+	*CollectorOpts
 	Host                       *prometheus.GaugeVec
 	Port                       *prometheus.GaugeVec
 	Id                         *prometheus.GaugeVec
@@ -63,11 +64,13 @@ type FSCollector struct {
 
 // NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
-func NewFSCollector(cluster string) *FSCollector {
+func NewFSCollector(opts *CollectorOpts) *FSCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &FSCollector{
+		CollectorOpts: opts,
 		StatBoot: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/fs.go
+++ b/collector/fs.go
@@ -388,7 +388,7 @@ func getEOSInstance() string {
 func (o *FSCollector) collectFSDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -70,7 +70,7 @@ func (o *FsckCollector) collectorList() []prometheus.Collector {
 func (o *FsckCollector) collectFsckDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -78,7 +78,7 @@ func (o *FsckCollector) collectFsckDF() error {
 
 	mds, err := client.FsckReport(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	o.Count.Reset()
@@ -108,6 +108,7 @@ func (o *FsckCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectFsckDF(); err != nil {
 		log.Println("failed collecting fsck metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/fsck.go
+++ b/collector/fsck.go
@@ -10,16 +10,19 @@ import (
 )
 
 type FsckCollector struct {
+	*CollectorOpts
 	Count *prometheus.GaugeVec
 }
 
 // NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
-func NewFsckCollector(cluster string) *FsckCollector {
+func NewFsckCollector(opts *CollectorOpts) *FsckCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &FsckCollector{
+		CollectorOpts: opts,
 		Count: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/fusex.go
+++ b/collector/fusex.go
@@ -92,7 +92,7 @@ func (o *FusexCollector) collectorList() []prometheus.Collector {
 func (o *FusexCollector) collectFusexDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/fusex.go
+++ b/collector/fusex.go
@@ -100,7 +100,7 @@ func (o *FusexCollector) collectFusexDF() error {
 
 	mds, err := client.ListFusex(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	o.Info.Reset()
@@ -127,6 +127,7 @@ func (o *FusexCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectFusexDF(); err != nil {
 		log.Println("failed collecting fsck metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/fusex.go
+++ b/collector/fusex.go
@@ -58,16 +58,19 @@ blockedfunc=none
 */
 
 type FusexCollector struct {
+	*CollectorOpts
 	Info *prometheus.GaugeVec
 }
 
 // NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
-func NewFusexCollector(cluster string) *FusexCollector {
+func NewFusexCollector(opts *CollectorOpts) *FusexCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &FusexCollector{
+		CollectorOpts: opts,
 		Info: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/group.go
+++ b/collector/group.go
@@ -10,6 +10,7 @@ import (
 )
 
 type GroupCollector struct {
+	*CollectorOpts
 	Name                   *prometheus.GaugeVec
 	CfgStatus              *prometheus.GaugeVec
 	Nofs                   *prometheus.GaugeVec
@@ -38,11 +39,13 @@ type GroupCollector struct {
 
 // NewGroupCollector creates an cluster of the GroupCollector and instantiates
 // the individual metrics that show information about the Group.
-func NewGroupCollector(cluster string) *GroupCollector {
+func NewGroupCollector(opts *CollectorOpts) *GroupCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &GroupCollector{
+		CollectorOpts: opts,
 		CfgStatus: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   "eos",
@@ -292,7 +295,8 @@ func (o *GroupCollector) collectGroupDF() error {
 
 	mds, err := client.ListGroup(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		log.Println(err)
+		return err
 	}
 
 	// Reset gauge metrics to remove metrics of deleted groups

--- a/collector/group.go
+++ b/collector/group.go
@@ -287,7 +287,7 @@ func (o *GroupCollector) collectorList() []prometheus.Collector {
 func (o *GroupCollector) collectGroupDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/group.go
+++ b/collector/group.go
@@ -295,7 +295,6 @@ func (o *GroupCollector) collectGroupDF() error {
 
 	mds, err := client.ListGroup(context.Background(), "root")
 	if err != nil {
-		log.Println(err)
 		return err
 	}
 
@@ -473,6 +472,7 @@ func (o *GroupCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectGroupDF(); err != nil {
 		log.Println("failed collecting group metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/inspector.go
+++ b/collector/inspector.go
@@ -52,7 +52,7 @@ func (o *InspectorLayoutCollector) collectInspectorLayoutDF() error {
 
 	mds, err := client.ListInspectorLayout(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	o.Volume.Reset()
@@ -82,6 +82,7 @@ func (o *InspectorLayoutCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectInspectorLayoutDF(); err != nil {
 		log.Println("failed collecting eos inspector metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/inspector.go
+++ b/collector/inspector.go
@@ -44,7 +44,7 @@ func (o *InspectorLayoutCollector) collectorList() []prometheus.Collector {
 func (o *InspectorLayoutCollector) collectInspectorLayoutDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/inspector.go
+++ b/collector/inspector.go
@@ -10,16 +10,19 @@ import (
 )
 
 type InspectorLayoutCollector struct {
+	*CollectorOpts
 	Volume *prometheus.GaugeVec
 }
 
 // NewFSCollector creates an cluster of the FSCollector and instantiates
 // the individual metrics that show information about the FS.
-func NewInspectorLayoutCollector(cluster string) *InspectorLayoutCollector {
+func NewInspectorLayoutCollector(opts *CollectorOpts) *InspectorLayoutCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &InspectorLayoutCollector{
+		CollectorOpts: opts,
 		Volume: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/io.go
+++ b/collector/io.go
@@ -271,7 +271,7 @@ func (o *IOAppInfoCollector) collectorList() []prometheus.Collector {
 func (o *IOInfoCollector) collectIOInfoDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		fmt.Println("Panic error while getting new eosclient: ", err)
@@ -389,7 +389,7 @@ func (o *IOInfoCollector) collectIOInfoDF() error {
 func (o *IOAppInfoCollector) collectIOAppInfoDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/io.go
+++ b/collector/io.go
@@ -280,8 +280,7 @@ func (o *IOInfoCollector) collectIOInfoDF() error {
 
 	mds, err := client.ListIOInfo(context.Background())
 	if err != nil {
-		fmt.Println("Panic error while ListIOInfo: ", err)
-		panic(err)
+		return err
 	}
 
 	for _, m := range mds {
@@ -397,9 +396,8 @@ func (o *IOAppInfoCollector) collectIOAppInfoDF() error {
 	}
 
 	mds, err := client.ListIOAppInfo(context.Background())
-
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for _, m := range mds {
@@ -434,6 +432,7 @@ func (o *IOInfoCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectIOInfoDF(); err != nil {
 		log.Println("failed collecting IO info metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {
@@ -453,6 +452,7 @@ func (o *IOAppInfoCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectIOAppInfoDF(); err != nil {
 		log.Println("failed collecting IO info metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/io.go
+++ b/collector/io.go
@@ -11,6 +11,7 @@ import (
 )
 
 type IOInfoCollector struct {
+	*CollectorOpts
 	Total_bwd_seeks          *prometheus.GaugeVec
 	Total_bytes_bwd_wseek    *prometheus.GaugeVec
 	Total_bytes_deleted      *prometheus.GaugeVec
@@ -36,6 +37,7 @@ type IOInfoCollector struct {
 }
 
 type IOAppInfoCollector struct {
+	*CollectorOpts
 	Total_in  *prometheus.GaugeVec
 	Total_out *prometheus.GaugeVec
 	//Last_60s    *prometheus.GaugeVec
@@ -44,13 +46,14 @@ type IOAppInfoCollector struct {
 	//Last_86400s *prometheus.GaugeVec
 }
 
-//NewIOInfoCollector creates an cluster of the IOInfoCollector
-func NewIOInfoCollector(cluster string) *IOInfoCollector {
+// NewIOInfoCollector creates an cluster of the IOInfoCollector
+func NewIOInfoCollector(opts *CollectorOpts) *IOInfoCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &IOInfoCollector{
-
+		CollectorOpts: opts,
 		Total_bwd_seeks: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
@@ -207,13 +210,14 @@ func NewIOInfoCollector(cluster string) *IOInfoCollector {
 	}
 }
 
-//NewIOAppInfoCollector creates an cluster of the IOAppInfoCollector
-func NewIOAppInfoCollector(cluster string) *IOAppInfoCollector {
+// NewIOAppInfoCollector creates an cluster of the IOAppInfoCollector
+func NewIOAppInfoCollector(opts *CollectorOpts) *IOAppInfoCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &IOAppInfoCollector{
-
+		CollectorOpts: opts,
 		Total_in: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/node.go
+++ b/collector/node.go
@@ -14,7 +14,7 @@ const (
 )
 
 type NodeCollector struct {
-
+	*CollectorOpts
 	// UsedBytes displays the total used bytes in the Node
 	Host                  *prometheus.GaugeVec
 	Port                  *prometheus.GaugeVec
@@ -82,11 +82,13 @@ cfg.gw.ntx=10
 */
 
 // NewNodeCollector creates an cluster of the NodeCollector
-func NewNodeCollector(cluster string) *NodeCollector {
+func NewNodeCollector(opts *CollectorOpts) *NodeCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 
 	return &NodeCollector{
+		CollectorOpts: opts,
 		Status: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   "eos",

--- a/collector/node.go
+++ b/collector/node.go
@@ -298,7 +298,7 @@ func (o *NodeCollector) collectNodeDF() error {
 
 	mds, err := client.ListNode(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Reset gauge metrics to remove metrics of removed nodes
@@ -452,6 +452,7 @@ func (o *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectNodeDF(); err != nil {
 		log.Println("failed collecting node metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/node.go
+++ b/collector/node.go
@@ -290,7 +290,7 @@ func (o *NodeCollector) collectorList() []prometheus.Collector {
 func (o *NodeCollector) collectNodeDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/ns.go
+++ b/collector/ns.go
@@ -15,6 +15,7 @@ import (
 )
 
 type NSCollector struct {
+	*CollectorOpts
 	Boot_file_time                             *prometheus.GaugeVec
 	Boot_status                                *prometheus.GaugeVec
 	Boot_time                                  *prometheus.GaugeVec
@@ -50,6 +51,7 @@ type NSCollector struct {
 }
 
 type NSActivityCollector struct {
+	*CollectorOpts
 	Sum        *prometheus.GaugeVec
 	Last_5s    *prometheus.GaugeVec
 	Last_60s   *prometheus.GaugeVec
@@ -58,6 +60,7 @@ type NSActivityCollector struct {
 }
 
 type NSBatchCollector struct {
+	*CollectorOpts
 	Sum        *prometheus.GaugeVec
 	Last_5s    *prometheus.GaugeVec
 	Last_60s   *prometheus.GaugeVec
@@ -79,13 +82,15 @@ var err error
 	}
 }*/
 
-//NewNSCollector creates an instance of the NSCollector and instantiates
+// NewNSCollector creates an instance of the NSCollector and instantiates
 // the individual metrics that show information about the NS.
-func NewNSCollector(cluster string) *NSCollector {
+func NewNSCollector(opts *CollectorOpts) *NSCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &NSCollector{
+		CollectorOpts: opts,
 		Boot_file_time: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
@@ -377,13 +382,15 @@ func NewNSCollector(cluster string) *NSCollector {
 	}
 }
 
-//NewNSActivityCollector creates an instance of the NSActivityCollector and instantiates
+// NewNSActivityCollector creates an instance of the NSActivityCollector and instantiates
 // the individual metrics that show information about the NS activity.
-func NewNSActivityCollector(cluster string) *NSActivityCollector {
+func NewNSActivityCollector(opts *CollectorOpts) *NSActivityCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &NSActivityCollector{
+		CollectorOpts: opts,
 		Sum: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
@@ -432,13 +439,15 @@ func NewNSActivityCollector(cluster string) *NSActivityCollector {
 	}
 }
 
-//NewNSBatchCollector creates an instance of the NSBatchCollector and instantiates
+// NewNSBatchCollector creates an instance of the NSBatchCollector and instantiates
 // the individual metrics that show information about the NS activity.
-func NewNSBatchCollector(cluster string) *NSBatchCollector {
+func NewNSBatchCollector(opts *CollectorOpts) *NSBatchCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &NSBatchCollector{
+		CollectorOpts: opts,
 		Sum: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/ns.go
+++ b/collector/ns.go
@@ -552,10 +552,10 @@ func (o *NSBatchCollector) collectorList() []prometheus.Collector {
 	}
 }
 
-func getNSData() ([]*eosclient.NSInfo, []*eosclient.NSActivityInfo, []*eosclient.NSBatchInfo, error) {
+func getNSData(o *CollectorOpts) ([]*eosclient.NSInfo, []*eosclient.NSActivityInfo, []*eosclient.NSBatchInfo, error) {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		fmt.Println("Panic error when creating eosclient in getNSData")
@@ -573,7 +573,7 @@ func getNSData() ([]*eosclient.NSInfo, []*eosclient.NSActivityInfo, []*eosclient
 
 func (o *NSCollector) collectNSDF() error {
 
-	Mds, Mdsact, Mdsbatch, err = getNSData()
+	Mds, Mdsact, Mdsbatch, err = getNSData(o.CollectorOpts)
 	if err != nil {
 		return err
 	}

--- a/collector/ns.go
+++ b/collector/ns.go
@@ -564,8 +564,7 @@ func getNSData() ([]*eosclient.NSInfo, []*eosclient.NSActivityInfo, []*eosclient
 
 	mds, mdsact, mdsbatch, err := client.ListNS(context.Background())
 	if err != nil {
-		fmt.Println("Panic error in ListNS")
-		panic(err)
+		return nil, nil, nil, err
 	}
 
 	return mds, mdsact, mdsbatch, nil
@@ -576,7 +575,7 @@ func (o *NSCollector) collectNSDF() error {
 
 	Mds, Mdsact, Mdsbatch, err = getNSData()
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	//var boot_status float64
@@ -915,6 +914,7 @@ func (o *NSCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectNSDF(); err != nil {
 		log.Println("failed collecting ns metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {
@@ -935,6 +935,7 @@ func (o *NSActivityCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectNSActivityDF(); err != nil {
 		log.Println("failed collecting ns_activity metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {
@@ -955,6 +956,7 @@ func (o *NSBatchCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectNSBatchDF(); err != nil {
 		log.Println("failed collecting space metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -17,18 +17,21 @@ import (
 // recycle-bin=/eos/homecanary/proc/recycle/ usedbytes=365327522885 maxbytes=100000000000000 volumeusage=0.37% inodeusage=1.19% lifetime=15552000 ratio=0.800000
 
 type RecycleCollector struct {
+	*CollectorOpts
 	UsedBytes *prometheus.GaugeVec
 	MaxBytes  *prometheus.GaugeVec
 	Lifetime  *prometheus.GaugeVec
 	Ratio     *prometheus.GaugeVec
 }
 
-//NewRecycleCollector creates an cluster of the RecycleCollector
-func NewRecycleCollector(cluster string) *RecycleCollector {
+// NewRecycleCollector creates an cluster of the RecycleCollector
+func NewRecycleCollector(opts *CollectorOpts) *RecycleCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &RecycleCollector{
+		CollectorOpts: opts,
 		UsedBytes: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -91,7 +91,7 @@ func (o *RecycleCollector) collectRecycleDF() error {
 
 	mds, err := client.Recycle(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for _, m := range mds {
@@ -133,6 +133,7 @@ func (o *RecycleCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectRecycleDF(); err != nil {
 		log.Println("failed collecting recycle metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/recycle.go
+++ b/collector/recycle.go
@@ -83,7 +83,7 @@ func (o *RecycleCollector) collectorList() []prometheus.Collector {
 func (o *RecycleCollector) collectRecycleDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/space.go
+++ b/collector/space.go
@@ -44,6 +44,7 @@ sum.stat.disk.bw?configstatus@rw=63069
 */
 
 type SpaceCollector struct {
+	*CollectorOpts
 	CfgGroupSize                         *prometheus.GaugeVec
 	CfgGroupMod                          *prometheus.GaugeVec
 	Nofs                                 *prometheus.GaugeVec
@@ -76,12 +77,13 @@ type SpaceCollector struct {
 }
 
 // NewSpaceCollector creates an cluster of the SpaceCollector
-func NewSpaceCollector(cluster string) *SpaceCollector {
+func NewSpaceCollector(opts *CollectorOpts) *SpaceCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 	namespace := "eos"
 	return &SpaceCollector{
-
+		CollectorOpts: opts,
 		CfgGroupSize: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,
@@ -385,7 +387,7 @@ func (o *SpaceCollector) collectorList() []prometheus.Collector {
 func (o *SpaceCollector) collectSpaceDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)

--- a/collector/space.go
+++ b/collector/space.go
@@ -395,7 +395,7 @@ func (o *SpaceCollector) collectSpaceDF() error {
 
 	mds, err := client.ListSpace(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// reset gauges (to drop metrics of deleted spaces)
@@ -609,6 +609,7 @@ func (o *SpaceCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectSpaceDF(); err != nil {
 		log.Println("failed collecting space metrics:", err)
+		return
 	}
 
 	for _, metric := range o.collectorList() {

--- a/collector/who.go
+++ b/collector/who.go
@@ -27,12 +27,14 @@ import (
 // This collector provides metrics based on c)
 
 type WhoCollector struct {
+	*CollectorOpts
 	SessionNumber *prometheus.GaugeVec
 	file          *os.File
 }
 
-//NewWhoCollector creates an cluster of the WhoCollector
-func NewWhoCollector(cluster string) *WhoCollector {
+// NewWhoCollector creates an cluster of the WhoCollector
+func NewWhoCollector(opts *CollectorOpts) *WhoCollector {
+	cluster := opts.Cluster
 	labels := make(prometheus.Labels)
 	labels["cluster"] = cluster
 
@@ -45,6 +47,7 @@ func NewWhoCollector(cluster string) *WhoCollector {
 
 	return &WhoCollector{
 		//file: f,
+		CollectorOpts: opts,
 		SessionNumber: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace:   namespace,

--- a/collector/who.go
+++ b/collector/who.go
@@ -77,7 +77,7 @@ func (o *WhoCollector) collectWhoDF() error {
 
 	whos, err := client.Who(context.Background(), "root")
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	//t := time.Now().String()
@@ -123,6 +123,7 @@ func (o *WhoCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if err := o.collectWhoDF(); err != nil {
 		log.Println("failed collecting who  metrics:", err)
+		return
 	}
 
 	for _, collector := range o.collectorList() {

--- a/collector/who.go
+++ b/collector/who.go
@@ -69,7 +69,7 @@ func (o *WhoCollector) collectorList() []prometheus.Collector {
 func (o *WhoCollector) collectWhoDF() error {
 	ins := getEOSInstance()
 	url := "root://" + ins
-	opt := &eosclient.Options{URL: url}
+	opt := &eosclient.Options{URL: url, Timeout: o.Timeout}
 	client, err := eosclient.New(opt)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes #33 

This PR adds:
- CollectorOpts for all collectors to pass configuration options (timeout for now)
- New Timeout configuration option to control timing when querying EOS
- Removal of panics to avoid crashing the process and loosing metrics (the error is logged instead, see below)
- `make build` builds the Go binary with all required build info (from `.get_build_info.sh`

How to test?

```
/var/tmp/eos_exporter -eos-instance eoshomedev -listen-address localhost:9999 -timeout 1
2024/02/22 09:29:58 Starting eos exporter for instance eoshomedev
&{0xc0001665a0}&{0xc000166660}&{0xc000166720}&{0xc0001667e0}&{0xc000166900}2024/02/22 09:29:58 Listening on localhost:9999
....
2024/02/22 09:30:03 failed collecting node metrics: signal: killed
....
```

